### PR TITLE
Fix assets resolving bug in epub.js

### DIFF
--- a/epub.js
+++ b/epub.js
@@ -59,7 +59,7 @@ const resolveURL = (url, relativeTo) => {
     try {
         if (relativeTo.includes(':')) return new URL(url, relativeTo)
         // the base needs to be a valid URL, so set a base URL and then remove it
-        const root = 'whatever:///'
+        const root = 'whatever://whatever/'
         return decodeURI(new URL(url, root + relativeTo).href.replace(root, ''))
     } catch(e) {
         console.warn(e)


### PR DESCRIPTION
When assets are located in the root folder, can't resolve its path with "new URL("../stylesheet.css", "whatever:///b/path.html")". It will return "whatever:///b/stylesheet.css" instead of "whatever:///stylesheet.css". This commit fixes the bug by replacing "whatever:///" with "whatever://whatever/".

example file:
[Redemption.zip](https://github.com/johnfactotum/foliate-js/files/11010069/Redemption.zip)
