### PR TITLE
Add MutationObserver alongside ResizeObserver

### DIFF
--- a/fixed-layout.js
+++ b/fixed-layout.js
@@ -31,7 +31,8 @@ const getViewport = (doc, viewport) => {
 
 export class FixedLayout extends HTMLElement {
     #root = this.attachShadow({ mode: 'closed' })
-    #observer = new ResizeObserver(() => this.#render())
+    #resizeObserver = new ResizeObserver(() => this.#render())
+    #mutationObserver = new MutationObserver(() => this.#render())
     #spreads
     #index = -1
     defaultViewport
@@ -54,7 +55,8 @@ export class FixedLayout extends HTMLElement {
             align-items: center;
         }`)
 
-        this.#observer.observe(this)
+        this.#resizeObserver.observe(this)
+        this.#mutationObserver.observe(this, { childList: true, subtree: true })
     }
     async #createFrame({ index, src }) {
         const element = document.createElement('div')
@@ -286,7 +288,8 @@ export class FixedLayout extends HTMLElement {
         }))
     }
     destroy() {
-        this.#observer.unobserve(this)
+        this.#resizeObserver.unobserve(this)
+        this.#mutationObserver.unobserve(this)
     }
 }
 

--- a/fixed-layout.js
+++ b/fixed-layout.js
@@ -31,8 +31,18 @@ const getViewport = (doc, viewport) => {
 
 export class FixedLayout extends HTMLElement {
     #root = this.attachShadow({ mode: 'closed' })
+    #wait = ms => new Promise(resolve => setTimeout(resolve, ms))
     #resizeObserver = new ResizeObserver(() => this.#render())
-    #mutationObserver = new MutationObserver(() => this.#render())
+//    #mutationObserver = new MutationObserver(async () => {
+//        console.log("befre...")
+//        await this.#wait(100)
+//        requestAnimationFrame(() => {
+//        console.log("in...")
+//            this.render()
+//        })
+////        await this.#wait(100)
+////        this.#render()
+//    })
     #spreads
     #index = -1
     defaultViewport
@@ -56,7 +66,7 @@ export class FixedLayout extends HTMLElement {
         }`)
 
         this.#resizeObserver.observe(this)
-        this.#mutationObserver.observe(this, { childList: true, subtree: true })
+//        this.#mutationObserver.observe(this.#root, { childList: true, subtree: true, attributes: true })
     }
     async #createFrame({ index, src }) {
         const element = document.createElement('div')
@@ -289,7 +299,7 @@ export class FixedLayout extends HTMLElement {
     }
     destroy() {
         this.#resizeObserver.unobserve(this)
-        this.#mutationObserver.unobserve(this)
+//        this.#mutationObserver.unobserve(this.#root)
     }
 }
 

--- a/paginator.js
+++ b/paginator.js
@@ -156,7 +156,9 @@ class View {
         this.expand()
     })
     #mutationObserver = new MutationObserver(async () => {
-        this.needsRenderForMutation = true
+        if (this.#column) {
+            this.needsRenderForMutation = true
+        }
     })
     needsRenderForMutation = false
     #element = document.createElement('div')

--- a/paginator.js
+++ b/paginator.js
@@ -489,7 +489,6 @@ export class Paginator extends HTMLElement {
         this.#footer = this.#root.getElementById('footer')
 
         this.#resizeObserver.observe(this.#container)
-        this.#mutationObserver.observe(this.#container, { childList: true, subtree: true })
         this.#container.addEventListener('scroll', debounce(() => {
             if (this.scrolled) {
                 this.#afterScroll('scroll')
@@ -989,7 +988,6 @@ export class Paginator extends HTMLElement {
     }
     destroy() {
         this.#resizeObserver.unobserve(this)
-        this.#mutationObserver.unobserve(this)
         this.#view.destroy()
         this.#view = null
         this.sections[this.#index]?.unload?.()


### PR DESCRIPTION
I'm using userscripts (foliate-js inside a webview in a swift app...) to manipulate the content of ebooks for educational purposes. This PR adds a mutation observer to trigger rendering when content is changed.