### PR TITLE
EPUB: Find cover in non-conformant epub3

### DIFF
--- a/epub.js
+++ b/epub.js
@@ -543,6 +543,8 @@ class Resources {
             }))
 
         this.cover = this.getItemByProperty('cover-image')
+            // Workaround epubs that are not spec conformant.
+            ?? this.getItemByID('cover')
             // EPUB 2 compat
             ?? this.getItemByID($$$(opf, 'meta')
                 .find(filterAttribute('name', 'cover'))


### PR DESCRIPTION
Some epubs from Kobo violate the epub spec in how they specify the cover image.  Instead of defining an `<item>` with attribute `[properties="cover-image"]`, they use attribute `[id="cover"]`.