### PR TITLE
Fix bad resolution for pdfs

### DIFF
--- a/pdf.js
+++ b/pdf.js
@@ -494,7 +494,13 @@ const annotationLayerBuilderCSS = `
 `
 
 const renderPage = async (page, getImageBlob) => {
-    const scale = devicePixelRatio
+
+    const naturalPdfSize = page.getViewport({ scale: 1 })
+    const naturalPdfRatio = naturalPdfSize.width / naturalPdfSize.height
+    const appRatio = innerWidth / innerHeight
+    const pdfToAppResolutionRatio = appRatio / naturalPdfRatio
+
+    const scale = devicePixelRatio * pdfToAppResolutionRatio
     const viewport = page.getViewport({ scale })
 
     const canvas = document.createElement('canvas')


### PR DESCRIPTION
Typical page size in PDF units is 612x792. Most of displays are 110-146 dpi nowadays. and if you want to get a page on your 3008x1692 screen, you will be looking at scale 2.0-5.0 times.

Before:
![2024-04-23T07:51:28,013278780+00:00](https://github.com/johnfactotum/foliate-js/assets/61885695/991a6913-02b4-4729-925a-bd7244acb408)

Afterwards:
![2024-04-23T07:50:34,392889898+00:00](https://github.com/johnfactotum/foliate-js/assets/61885695/955df770-db70-4c34-ab9b-5039a48fb751)
