### PR TITLE
Close the "not" function

### DIFF
--- a/epub.js
+++ b/epub.js
@@ -702,7 +702,7 @@ class Loader {
             for (const el of doc.querySelectorAll('[src]')) await replace(el, 'src')
             for (const el of doc.querySelectorAll('[poster]')) await replace(el, 'poster')
             for (const el of doc.querySelectorAll('object[data]')) await replace(el, 'data')
-            for (const el of doc.querySelectorAll('[*|href]:not([href]'))
+            for (const el of doc.querySelectorAll('[*|href]:not([href])'))
                 el.setAttributeNS(NS.XLINK, 'href', await this.loadHref(
                     el.getAttributeNS(NS.XLINK, 'href'), href, parents))
             // replace inline styles


### PR DESCRIPTION
the querySelectorAll of a element "_[*|href]:not([href)_" was not correctly closed (needs closing square brackets)