### PR TITLE
Allow book urls to be relative

### DIFF
--- a/reader.js
+++ b/reader.js
@@ -324,6 +324,6 @@ const params = new URLSearchParams(location.search)
 const url = params.get('url')
 if (url) fetch(url)
     .then(res => res.blob())
-    .then(blob => open(new File([blob], new URL(url).pathname)))
+    .then(blob => open(new File([blob], new URL(url, window.location.origin).pathname)))
     .catch(e => console.error(e))
 else dropTarget.style.visibility = 'visible'


### PR DESCRIPTION
When using reader.html with `url` parameter, it expects it to be full complete url. e.g. `http://localhost:2015/reader.html?url=http://localhost:2015/books/aliceinwonderland.epub`. This change allows it to skip the base part of the url. i.e. `http://localhost:2015/reader.html?url=/books/wizard-of-oz.epub`. This way the urls are valid both on localhost and when served under a domain.

I have a simple html index for my books list (with epubjs-reader for now). I would like to use this library without having to hardcode domain in all the links.
```
<h2>classic books</h2>
<ul>
	<li><a target="_blank" href="reader/?bookPath=/books/classic-stories/aliceinwonderland.epub">Alice's Adventures in Wonderland</a></li>
	<li><a target="_blank" href="reader/?bookPath=/books/classic-stories/through-the-looking-glass.epub">Through the Looking-Glass</a></li>
	<li><a target="_blank" href="reader/?bookPath=/books/classic-stories/wizard-of-oz.epub">The Wonderful Wizard of Oz</a></li>
</ul>
```
Ref: https://developer.mozilla.org/en-US/docs/Web/API/URL/URL

---

### Error without this change
```
TypeError: URL constructor: /books/wizard-of-oz.epub is not a valid URL.
    <anonymous> http://localhost:2015/reader.js:327
[reader.js:328:25](http://localhost:2015/reader.js)
    <anonymous> http://localhost:2015/reader.js:328
```