### PR TITLE
Lazy loading of PDF documents (#37)

### DIFF
--- a/pdf.js
+++ b/pdf.js
@@ -105,9 +105,14 @@ const makeTOCItem = item => ({
 })
 
 export const makePDF = async file => {
-    const data = new Uint8Array(await file.arrayBuffer())
+    const transport = new pdfjsLib.PDFDataRangeTransport(file.size, [])
+    transport.requestDataRange = (begin, end) => {
+        file.slice(begin, end).arrayBuffer().then(chunk => {
+            transport.onDataRange(begin, chunk)
+        })
+    }
     const pdf = await pdfjsLib.getDocument({
-        data,
+        range: transport,
         cMapUrl: pdfjsPath('cmaps/'),
         standardFontDataUrl: pdfjsPath('standard_fonts/'),
         isEvalSupported: false,


### PR DESCRIPTION
In this way well structured PDF document can be loaded progressively aka. lazy loading only the data for pages that is about to be rendered. This should close #37.