### PR TITLE
[WIP] Merge enhancements and fixes from Readest project into foliate-js upstream

### DIFF
--- a/epub.js
+++ b/epub.js
@@ -203,7 +203,7 @@ const getMetadata = opf => {
         if (!els) return null
         return Object.groupBy(els.map(parse), x => x.property)
     }
-    const dc = Object.fromEntries(Object.entries(Object.groupBy(els.dc, el => el.localName))
+    const dc = Object.fromEntries(Object.entries(Object.groupBy(els.dc || [], el => el.localName))
         .map(([name, els]) => [name, els.map(parse)]))
     const properties = getProperties() ?? {}
     const legacyMeta = Object.fromEntries(els.legacyMeta?.map(el =>

--- a/epub.js
+++ b/epub.js
@@ -870,6 +870,15 @@ class Loader {
                 `-webkit-column-break-${x}:`)
             .replace(/break-(after|before|inside)\s*:\s*(avoid-)?page/gi, (_, x, y) =>
                 `break-${x}: ${y ?? ''}column`)
+            // replace absolute font sizes with rem units
+            .replace(/font-size\s*:\s*xx-small/gi, 'font-size: 0.6rem')
+            .replace(/font-size\s*:\s*x-small/gi, 'font-size: 0.75rem')
+            .replace(/font-size\s*:\s*small/gi, 'font-size: 0.875rem')
+            .replace(/font-size\s*:\s*medium/gi, 'font-size: 1rem')
+            .replace(/font-size\s*:\s*large/gi, 'font-size: 1.2rem')
+            .replace(/font-size\s*:\s*x-large/gi, 'font-size: 1.5rem')
+            .replace(/font-size\s*:\s*xx-large/gi, 'font-size: 2rem')
+            .replace(/font-size\s*:\s*xxx-large/gi, 'font-size: 3rem')
     }
     // find & replace all possible relative paths for all assets without parsing
     replaceString(str, href, parents = []) {

--- a/epub.js
+++ b/epub.js
@@ -94,7 +94,7 @@ const childGetter = (doc, ns) => {
 
 const resolveURL = (url, relativeTo) => {
     try {
-        if (relativeTo.includes(':')) return new URL(url, relativeTo)
+        if (relativeTo.includes(':') && !relativeTo.startsWith('OEBPS')) return new URL(url, relativeTo)
         // the base needs to be a valid URL, so set a base URL and then remove it
         const root = 'https://invalid.invalid/'
         const obj = new URL(url, root + relativeTo)
@@ -669,6 +669,8 @@ class Resources {
             ?? this.getItemByID($$$(opf, 'meta')
                 .find(filterAttribute('name', 'cover'))
                 ?.getAttribute('content'))
+            ?? this.manifest.find(item => item.href.includes('cover')
+                && item.mediaType.startsWith('image'))
             ?? this.getItemByHref(this.guide
                 ?.find(ref => ref.type.includes('cover'))?.href)
 
@@ -859,7 +861,7 @@ class Loader {
         const h = window?.innerHeight ?? 600
         return replacedImports
             // unprefix as most of the props are (only) supported unprefixed
-            .replace(/(?<=[{\s;])-epub-/gi, '')
+            .replace(/([{\s;])-epub-/gi, '$1')
             // replace vw and vh as they cause problems with layout
             .replace(/(\d*\.?\d+)vw/gi, (_, d) => parseFloat(d) * w / 100 + 'px')
             .replace(/(\d*\.?\d+)vh/gi, (_, d) => parseFloat(d) * h / 100 + 'px')

--- a/epub.js
+++ b/epub.js
@@ -879,6 +879,9 @@ class Loader {
             .replace(/font-size\s*:\s*x-large/gi, 'font-size: 1.5rem')
             .replace(/font-size\s*:\s*xx-large/gi, 'font-size: 2rem')
             .replace(/font-size\s*:\s*xxx-large/gi, 'font-size: 3rem')
+            // replace hardcoded colors
+            .replace(/color\s*:\s*#000000/gi, 'color: unset')
+            .replace(/color\s*:\s*#000/gi, 'color: unset')
     }
     // find & replace all possible relative paths for all assets without parsing
     replaceString(str, href, parents = []) {

--- a/fixed-layout.js
+++ b/fixed-layout.js
@@ -1,3 +1,5 @@
+import 'construct-style-sheets-polyfill'
+
 const parseViewport = str => str
     ?.split(/[,;\s]/) // NOTE: technically, only the comma is valid
     ?.filter(x => x)

--- a/footnotes.js
+++ b/footnotes.js
@@ -93,9 +93,9 @@ export class FootnoteHandler extends EventTarget {
         })
     }
     handle(book, e) {
-        const { a, href } = e.detail
+        const { a, href, follow } = e.detail
         const { yes, maybe } = isFootnoteReference(a)
-        if (yes) {
+        if (yes || follow) {
             e.preventDefault()
             return Promise.resolve(book.resolveHref(href)).then(target =>
                 this.#showFragment(book, target, href))

--- a/footnotes.js
+++ b/footnotes.js
@@ -62,10 +62,18 @@ export class FootnoteHandler extends EventTarget {
                     const type = getReferencedType(el)
                     const hidden = el?.matches?.('aside') && type === 'footnote'
                     if (el) {
-                        const range = el.startContainer ? el : doc.createRange()
-                        if (!el.startContainer) {
-                            if (el.matches('li, aside')) range.selectNodeContents(el)
-                            else range.selectNode(el)
+                        let range
+                        if (el.startContainer) {
+                            range = el
+                        } else if (el.matches('li, aside')) {
+                            range = doc.createRange()
+                            range.selectNodeContents(el)
+                        } else if (el.closest('li')) {
+                            range = doc.createRange()
+                            range.selectNodeContents(el.closest('li'))
+                        } else {
+                            range = doc.createRange()
+                            range.selectNode(el)
                         }
                         const frag = range.extractContents()
                         doc.body.replaceChildren()

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "foliate-js",
       "version": "0.0.0",
       "license": "MIT",
+      "dependencies": {
+        "construct-style-sheets-polyfill": "^3.1.0"
+      },
       "devDependencies": {
         "@eslint/js": "^9.9.1",
         "@rollup/plugin-node-resolve": "^15.2.3",
@@ -595,6 +598,12 @@
       "dev": true,
       "license": "ISC",
       "optional": true
+    },
+    "node_modules/construct-style-sheets-polyfill": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmmirror.com/construct-style-sheets-polyfill/-/construct-style-sheets-polyfill-3.1.0.tgz",
+      "integrity": "sha512-HBLKP0chz8BAY6rBdzda11c3wAZeCZ+kIG4weVC2NM3AXzxx09nhe8t0SQNdloAvg5GLuHwq/0SPOOSPvtCcKw==",
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.3.7",

--- a/package.json
+++ b/package.json
@@ -43,5 +43,8 @@
     "dictd",
     "stardict",
     "opds"
-  ]
+  ],
+  "dependencies": {
+    "construct-style-sheets-polyfill": "^3.1.0"
+  }
 }

--- a/paginator.js
+++ b/paginator.js
@@ -536,7 +536,7 @@ export class Paginator extends HTMLElement {
         <div id="top">
             <div id="background" part="filter"></div>
             <div id="header"></div>
-            <div id="container"></div>
+            <div id="container" part="container"></div>
             <div id="footer"></div>
         </div>
         `

--- a/paginator.js
+++ b/paginator.js
@@ -281,12 +281,12 @@ class View {
         if (this.#column) this.columnize(layout)
         else this.scrolled(layout)
     }
-    scrolled({ gap, columnWidth }) {
+    scrolled({ margin, gap, columnWidth }) {
         const vertical = this.#vertical
         const doc = this.document
         setStylesImportant(doc.documentElement, {
             'box-sizing': 'border-box',
-            'padding': vertical ? `${gap}px 0` : `0 ${gap}px`,
+            'padding': vertical ? `${margin*1.5}px ${gap}px` : `0 ${gap}px`,
             'column-width': 'auto',
             'height': 'auto',
             'width': 'auto',
@@ -298,7 +298,7 @@ class View {
         this.setImageSize()
         this.expand()
     }
-    columnize({ width, height, gap, columnWidth }) {
+    columnize({ width, height, margin, gap, columnWidth }) {
         const vertical = this.#vertical
         this.#size = vertical ? height : width
 
@@ -306,12 +306,12 @@ class View {
         setStylesImportant(doc.documentElement, {
             'box-sizing': 'border-box',
             'column-width': `${Math.trunc(columnWidth)}px`,
-            'column-gap': `${gap}px`,
+            'column-gap': vertical ? `${margin}px` : `${gap}px`,
             'column-fill': 'auto',
             ...(vertical
                 ? { 'width': `${width}px` }
                 : { 'height': `${height}px` }),
-            'padding': vertical ? `${gap / 2}px 0` : `0 ${gap / 2}px`,
+            'padding': vertical ? `${margin / 2}px ${gap / 2}px` : `${margin / 2}px ${gap / 2}px`,
             'overflow': 'hidden',
             // force wrap long words
             'overflow-wrap': 'break-word',
@@ -383,8 +383,8 @@ class View {
             const otherSide = this.#vertical ? 'height' : 'width'
             const contentSize = documentElement.getBoundingClientRect()[side]
             const expandedSize = contentSize
-            const { margin } = this.#layout
-            const padding = this.#vertical ? `0 ${margin}px` : `${margin}px 0`
+            const { margin, gap } = this.#layout
+            const padding = this.#vertical ? `0 ${gap}px` : `${margin}px 0`
             this.#element.style.padding = padding
             this.#iframe.style[side] = `${expandedSize}px`
             this.#element.style[side] = `${expandedSize}px`
@@ -627,6 +627,7 @@ export class Paginator extends HTMLElement {
             case 'max-block-size':
             case 'max-column-count':
                 this.#top.style.setProperty('--_' + name, value)
+                this.render()
                 break
             case 'max-inline-size':
                 // needs explicit `render()` as it doesn't necessarily resize
@@ -724,7 +725,7 @@ export class Paginator extends HTMLElement {
         }
 
         const divisor = Math.min(maxColumnCount, Math.ceil(size / maxInlineSize))
-        const columnWidth = (size / divisor) - gap
+        const columnWidth = vertical ? (size / divisor - margin) : (size / divisor - gap)
         this.setAttribute('dir', rtl ? 'rtl' : 'ltr')
 
         // set background to `doc` background

--- a/text-walker.js
+++ b/text-walker.js
@@ -32,7 +32,7 @@ export const textWalker = function* (x, func) {
     const walker = document.createTreeWalker(root, filter, { acceptNode })
     const walk = x.commonAncestorContainer ? walkRange : walkDocument
     const nodes = walk(x, walker)
-    const strs = nodes.map(node => node.nodeValue)
+    const strs = nodes.map(node => node.nodeValue ?? '')
     const makeRange = (startIndex, startOffset, endIndex, endOffset) => {
         const range = document.createRange()
         range.setStart(nodes[startIndex], startOffset)

--- a/tts.js
+++ b/tts.js
@@ -25,7 +25,7 @@ const getSegmenter = (lang = 'en', granularity = 'word') => {
     const segmenter = new Intl.Segmenter(lang, { granularity })
     const granularityIsWord = granularity === 'word'
     return function* (strs, makeRange) {
-        const str = strs.join('')
+        const str = strs.join('').replace(/\r\n/g, '  ').replace(/\r/g, ' ').replace(/\n/g, ' ')
         let name = 0
         let strIndex = -1
         let sum = 0

--- a/view.js
+++ b/view.js
@@ -402,7 +402,7 @@ export class View extends HTMLElement {
             .find(x => x.index === index && x.overlayer)
     }
     #createOverlayer({ doc, index }) {
-        const overlayer = new Overlayer()
+        const overlayer = new Overlayer(doc)
         doc.addEventListener('click', e => {
             const [value, range] = overlayer.hitTest(e)
             if (value && !value.startsWith(SEARCH_PREFIX)) {

--- a/view.js
+++ b/view.js
@@ -256,7 +256,7 @@ export class View extends HTMLElement {
             await import('./paginator.js')
             this.renderer = document.createElement('foliate-paginator')
         }
-        this.renderer.setAttribute('exportparts', 'head,foot,filter')
+        this.renderer.setAttribute('exportparts', 'head,foot,filter,container')
         this.renderer.addEventListener('load', e => this.#onLoad(e.detail))
         this.renderer.addEventListener('relocate', e => this.#onRelocate(e.detail))
         this.renderer.addEventListener('create-overlayer', e =>


### PR DESCRIPTION
This PR merges the changes made in the foliate-js submodule on the [Readest](https://github.com/chrox/readest) project as discussed in the [Windows build issue](https://github.com/johnfactotum/foliate/issues/115#issuecomment-2510205676) of the foliate project. These changes aim to enhance functionality and fix issues encountered during integration. By merging these updates into the upstream foliate-js, future versions of Readest can directly include the foliate-js as a dependency, ensuring alignment with the upstream repository and simplifying maintenance.

**Summary of Changes:**

1: Avoid the use of Lookbehind regex which is not supported on WebKit version below 614.3.7.1.5;
2: Polyfill CSSStyleSheet constructor which is not supported on WebKit version below 615.1.26.11.22;
3: Avoid the use of module top-level await which is not supported on WebKit version below 613.3.9.1.16;
4: Web Workers loading scripts in `pdfjsPath` now from the base `/` that's the `public` directory of a Next.js project;
5: Use `@pdfjs` instead of hard coding `dist` files path of `pdfjs` so that we can alias `@pdfjs` to the `public` directory;
~~6: A hack to auto-hide the scrollbar by padding in `container` other than the `iframe`, so that `container` could grab the `mouseleave` event and hide the scrollbar on macOS, otherwise once the scrollbar is shown it will be visible forever which is quite annoying on macOS;~~
~~7: To implement [Parallel View](https://readest.com/#parallel-read) in Readest, the scrollTo function of the paginator should be public.~~

**Additional Notes:**

Let me know if there are any adjustments or further refinements required for compatibility or style. Thank you for reviewing this patch! Looking forward to discussing and refining these updates for inclusion in foliate-js.
