### PR TITLE
Fix cover retrieval when using EPUB2

### DIFF
--- a/epub.js
+++ b/epub.js
@@ -666,7 +666,7 @@ class Resources {
 
         this.cover = this.getItemByProperty('cover-image')
             // EPUB 2 compat
-            ?? this.getItemByID($$$(opf, 'meta')
+            ?? resolveHref($$$(opf, 'meta')
                 .find(filterAttribute('name', 'cover'))
                 ?.getAttribute('content'))
             ?? this.getItemByHref(this.guide


### PR DESCRIPTION
The cover retrieval fallback for EPUB2 retrieves content from the metadata section however `getItemByID` searches in the manifest section. This means the cover was never found when using this fallback.

Example simplified file:

```
<metadata xmlns:dc="http://purl.org/dc/elements/1.1/"  xmlns:opf="http://www.idpf.org/2007/opf">
    <meta name="cover" content="Images/Cover.png"/>
</metadata>
```