### PR TITLE
Prevent exception on Firefox due to getSelection returning null

### DIFF
--- a/paginator.js
+++ b/paginator.js
@@ -158,10 +158,12 @@ const setSelectionTo = (target, collapse) => {
     }
     if (range) {
         const sel = range.startContainer.ownerDocument.defaultView.getSelection()
-        sel.removeAllRanges()
-        if (collapse === -1) range.collapse(true)
-        else if (collapse === 1) range.collapse()
-        sel.addRange(range)
+        if (sel) {
+            sel.removeAllRanges()
+            if (collapse === -1) range.collapse(true)
+            else if (collapse === 1) range.collapse()
+            sel.addRange(range)
+        }
     }
 }
 


### PR DESCRIPTION
getSelection [is allowed to return null](https://developer.mozilla.org/en-US/docs/Web/API/Window/getSelection) on any browser.