### PR TITLE
Fix for FixedLayout.index returning incorrect values

### DIFF
--- a/fixed-layout.js
+++ b/fixed-layout.js
@@ -234,14 +234,14 @@ export class FixedLayout extends HTMLElement {
             else {
                 if (last.center || last.left) newSpread().right = section
                 else if (last.right || !i) last.left = section
-                else last .right = section
+                else last.right = section
             }
             return arr
         }, [{}])
     }
     get index() {
         const spread = this.#spreads[this.#index]
-        const section = spread?.center ?? (this.side === 'left'
+        const section = spread?.center ?? (this.#side === 'left'
             ? spread.left ?? spread.right : spread.right ?? spread.left)
         return this.book.sections.indexOf(section)
     }


### PR DESCRIPTION
this.side was never 'left'. This isn't necessarily problematic when viewing the full spread at once, but it means the value returned doesn't yield the same page as the one currently being displayed in a single page viewport.