### PR TITLE
Re-render single pages when paginating fixed layout

### DIFF
--- a/fixed-layout.js
+++ b/fixed-layout.js
@@ -295,12 +295,12 @@ export class FixedLayout extends HTMLElement {
     }
     async next() {
         const s = this.rtl ? this.#goLeft() : this.#goRight()
-        if (s) this.#reportLocation('page')
+        if (s) { this.#render(); this.#reportLocation('page') }
         else return this.goToSpread(this.#index + 1, this.rtl ? 'right' : 'left', 'page')
     }
     async prev() {
         const s = this.rtl ? this.#goRight() : this.#goLeft()
-        if (s) this.#reportLocation('page')
+        if (s) { this.#render(); this.#reportLocation('page') }
         else return this.goToSpread(this.#index - 1, this.rtl ? 'left' : 'right', 'page')
     }
     getContents() {

--- a/fixed-layout.js
+++ b/fixed-layout.js
@@ -179,18 +179,18 @@ export class FixedLayout extends HTMLElement {
     #goLeft() {
         if (this.#center || this.#left?.blank) return
         if (this.#portrait && this.#left?.element?.style?.display === 'none') {
-            this.#right.element.style.display = 'none'
-            this.#left.element.style.display = 'block'
             this.#side = 'left'
+            this.#render()
+            this.#reportLocation('page')
             return true
         }
     }
     #goRight() {
         if (this.#center || this.#right?.blank) return
         if (this.#portrait && this.#right?.element?.style?.display === 'none') {
-            this.#left.element.style.display = 'none'
-            this.#right.element.style.display = 'block'
             this.#side = 'right'
+            this.#render()
+            this.#reportLocation('page')
             return true
         }
     }
@@ -295,13 +295,11 @@ export class FixedLayout extends HTMLElement {
     }
     async next() {
         const s = this.rtl ? this.#goLeft() : this.#goRight()
-        if (s) { this.#render(); this.#reportLocation('page') }
-        else return this.goToSpread(this.#index + 1, this.rtl ? 'right' : 'left', 'page')
+        if (!s) return this.goToSpread(this.#index + 1, this.rtl ? 'right' : 'left', 'page')
     }
     async prev() {
         const s = this.rtl ? this.#goRight() : this.#goLeft()
-        if (s) { this.#render(); this.#reportLocation('page') }
-        else return this.goToSpread(this.#index - 1, this.rtl ? 'left' : 'right', 'page')
+        if (!s) return this.goToSpread(this.#index - 1, this.rtl ? 'left' : 'right', 'page')
     }
     getContents() {
         return Array.from(this.#root.querySelectorAll('iframe'), frame => ({


### PR DESCRIPTION
When the fixed layout renderer is in single page ("portrait") mode and the pages have different sizes and shapes, *not* re-rendering pages on #goLeft and #goRight can result (when the page change takes place within a spread) in pages retaining a downscale that matches a spread that's not visible, yielding a view with undesired margins/wasted space.

In the same circumstances, if paginating into the same page from outside the spread or directly using goTo, the page is re-rendered, which means it will take up the full available space. This is inconsistent and confusing.

This is a simple fix that ensures pages are always re-rendered in portrait mode and therefore always have the correct dimensions. I figured if the resize observer calls `#render`, it should be acceptable here as well, but feel free to amend the fix to make it more focused if possible.