### PR TITLE
fixed-layout method for obtaining current render details

### DIFF
--- a/fixed-layout.js
+++ b/fixed-layout.js
@@ -309,6 +309,17 @@ export class FixedLayout extends HTMLElement {
             // TODO: index, overlayer
         }))
     }
+    getRenderDetails() {
+        return {
+            leftWidth: this.#left?.element.clientWidth,
+            rightWidth: this.#right?.element.clientWidth,
+            centerWidth: this.#center?.element.clientWidth,
+            height: this.#left?.element.clientHeight
+                    || this.#right?.element.clientHeight
+                    || this.#center?.element.clientHeight,
+            side: this.#side
+        }
+    }
     destroy() {
         this.#observer.unobserve(this)
     }


### PR DESCRIPTION
Something like this is necessary for adding overlays or decorations to a viewer implementations that are aware of the proportions of the spread devoted to each page when pages have different sizes and shapes. The load event is insufficient because it's not spread-aware. I'm going with this for now, but I'm aware you may prefer a different syntax, possibly another event.