### PR TITLE
Fix for fixed-layout transform anchor point in RTL context.

### DIFF
--- a/fixed-layout.js
+++ b/fixed-layout.js
@@ -73,6 +73,7 @@ export class FixedLayout extends HTMLElement {
         const src = srcOptionIsString ? srcOption : srcOption?.src
         const onZoom = srcOptionIsString ? null : srcOption?.onZoom
         const element = document.createElement('div')
+        element.setAttribute("dir", "ltr")
         const iframe = document.createElement('iframe')
         element.append(iframe)
         Object.assign(iframe.style, {
@@ -137,7 +138,7 @@ export class FixedLayout extends HTMLElement {
                 width: `${width * iframeScale}px`,
                 height: `${height * iframeScale}px`,
                 transform: onZoom ? 'none' : `scale(${scale})`,
-                transformOrigin: 'top ' + (getComputedStyle(iframe).direction === 'rtl' ? 'right' : 'left'),
+                transformOrigin: 'top left',
                 display: blank ? 'none' : 'block',
             })
             Object.assign(element.style, {


### PR DESCRIPTION
If the viewer is running in an RTL context (this is not the same as the reading direction of the Book itself), and a fixed-layout rendered view is scaled (which is often the case), anchoring the transform to the left breaks page positioning. Unfortunately there doesn't seem to be a pure efficient CSS solution yet (something like "inline-start" and "inline-end"). This is one possible fix.

![image](https://github.com/user-attachments/assets/6385159a-2e53-4d83-adf7-5e53da7038ea)

![image](https://github.com/user-attachments/assets/88643b87-b08a-481a-bf49-8dfb4f39e5a1)
