### PR TITLE
Smart attribute for foliate-view adds smart spreads to comic books.

### DIFF
--- a/comic-book.js
+++ b/comic-book.js
@@ -1,4 +1,97 @@
-export const makeComicBook = ({ entries, loadBlob, getSize }, file) => {
+async function getJpgDimensions(blob) {
+    const header = await blob.slice(0, 2).arrayBuffer();
+    const view = new DataView(header);
+    if (view.getUint16(0) !== 0xFFD8) return null;  //JPEG SOI
+
+    let offset = 2;
+    while (offset < blob.size) {
+        const buffer = await blob.slice(offset, offset + 9).arrayBuffer();
+        if (buffer.byteLength < 4) return null;
+        const view = new DataView(buffer);
+        const marker = view.getUint16(0);
+        const length = view.getUint16(2);
+
+        // SOF0 (baseline DCT) or SOF2 (progressive DCT)
+        if (marker === 0xFFC0 || marker === 0xFFC2) {
+            const height = view.getUint16(5);
+            const width = view.getUint16(7);
+            return { width, height };
+        }
+
+        if (marker === 0xFFDA) return null;  //Image data
+
+        offset += 2 + length;
+    }
+
+    return null;
+}
+
+function getUint24LittleEndian(dataView, offset) {
+    return dataView.getUint8(offset)
+        | (dataView.getUint8(offset + 1) << 8)
+        | (dataView.getUint8(offset + 2) << 16);
+}
+
+async function getWebpDimensions(blob) {
+    const header = await blob.slice(0, 30).arrayBuffer();
+    const view = new DataView(header);
+
+    const riff = String.fromCharCode(...new Uint8Array(header.slice(0, 4)));
+    const webp = String.fromCharCode(...new Uint8Array(header.slice(8, 12)));
+    if (riff !== 'RIFF' || webp !== 'WEBP') return null;
+
+    const chunkType = String.fromCharCode(...new Uint8Array(header.slice(12, 16)));
+
+    if (chunkType === 'VP8 ') {
+        const width = view.getUint16(26, true) & 0x3FFF;
+        const height = view.getUint16(28, true) & 0x3FFF;
+        return { width, height };
+    }
+
+    if (chunkType === 'VP8L') {
+        const b0 = view.getUint8(21);
+        const b1 = view.getUint8(22);
+        const b2 = view.getUint8(23);
+        const b3 = view.getUint8(24);
+
+        const width = 1 + (((b1 & 0x3F) << 8) | b0);
+        const height = 1 + (((b3 & 0xF) << 10) | (b2 << 2) | ((b1 & 0xC0) >> 6));
+        return { width, height };
+    }
+
+    if (chunkType === 'VP8X') {
+        const width = 1 + getUint24LittleEndian(view, 24);
+        const height = 1 + getUint24LittleEndian(view, 27);
+        return { width, height };
+    }
+
+    return null;
+}
+
+const pageDimensions = {
+    jpg: getJpgDimensions,
+    jpeg: getJpgDimensions,
+    png: async (blob) => {
+        const header = await blob.slice(0, 24).arrayBuffer();
+        const view = new DataView(header);
+        if (view.getUint32(0) !== 0x89504E47) return null;  //PNG magic number
+        const width = view.getUint32(16);
+        const height = view.getUint32(20);
+        return { width, height };
+    },
+    gif: async (blob) => {
+        const header = await blob.slice(0, 10).arrayBuffer();
+        const view = new DataView(header);
+        const signature = String.fromCharCode(...new Uint8Array(header.slice(0, 6)));
+        if (!/^GIF8[79]a$/.test(signature)) return null; //GIF magic numbers
+        const width = view.getUint16(6, true);
+        const height = view.getUint16(8, true);
+        return { width, height };
+    },
+    webp: getWebpDimensions
+}
+
+export const makeComicBook = ({ entries, loadBlob, getSize }, file, smart) => {
     const cache = new Map()
     const urls = new Map()
     const load = async name => {
@@ -26,12 +119,16 @@ export const makeComicBook = ({ entries, loadBlob, getSize }, file) => {
     const book = {}
     book.getCover = () => loadBlob(files[0])
     book.metadata = { title: file.name }
-    book.sections = files.map(name => ({
-        id: name,
-        load: () => load(name),
-        unload: () => unload(name),
-        size: getSize(name),
-    }))
+    book.sections = files.map(name => {
+        const extension = name.slice((name.lastIndexOf(".") - 1 >>> 0) + 2);
+        return {
+            id: name,
+            load: () => load(name),
+            unload: () => unload(name),
+            size: getSize(name),
+            getDimensions: smart && pageDimensions[extension] ? () => loadBlob(name).then(blob => pageDimensions[extension](blob)) : () => {}
+        };
+    })
     book.toc = files.map(name => ({ label: name, href: name }))
     book.rendition = { layout: 'pre-paginated' }
     book.resolveHref = href => ({ index: book.sections.findIndex(s => s.id === href) })

--- a/fixed-layout.js
+++ b/fixed-layout.js
@@ -194,7 +194,7 @@ export class FixedLayout extends HTMLElement {
             return true
         }
     }
-    open(book) {
+    async open(book) {
         this.book = book
         const { rendition } = book
         this.spread = rendition?.spread
@@ -203,6 +203,20 @@ export class FixedLayout extends HTMLElement {
         const rtl = book.dir === 'rtl'
         const ltr = !rtl
         this.rtl = rtl
+
+        const promises = [];
+        book.sections.forEach((section) => {
+            if (!section.getDimensions) return;
+            const promise = section.getDimensions();
+            if (promise instanceof Promise) {
+                promises.push(promise);
+                promise.then((dimensions) => section.dimensions = dimensions);
+            } else if (typeof promise === "object") {
+                section.dimensions = promise;
+            }
+        });
+
+        await Promise.all(promises);
 
         if (rendition?.spread === 'none')
             this.#spreads = book.sections.map(section => ({ center: section }))
@@ -226,15 +240,21 @@ export class FixedLayout extends HTMLElement {
                 const spread = last.center || last.right || rtl && i ? newSpread() : last
                 spread.right = section
             }
-            else if (ltr) {
-                if (last.center || last.right) newSpread().left = section
-                else if (last.left || !i) last.right = section
-                else last.left = section
-            }
             else {
-                if (last.center || last.left) newSpread().right = section
-                else if (last.right || !i) last.left = section
-                else last.right = section
+                if (section.dimensions?.width > section.dimensions?.height * 1.05) {
+                    newSpread().center = section
+                } else {
+                    if (ltr) {
+                        if (last.center || last.right) newSpread().left = section
+                        else if (last.left || !i) last.right = section
+                        else last.left = section
+                    }
+                    else {
+                        if (last.center || last.left) newSpread().right = section
+                        else if (last.right || !i) last.left = section
+                        else last.right = section
+                    }
+                }
             }
             return arr
         }, [{}])

--- a/reader.js
+++ b/reader.js
@@ -105,6 +105,7 @@ class Reader {
     }
     async open(file) {
         this.view = document.createElement('foliate-view')
+        //this.view.setAttribute("smart", true);
         document.body.append(this.view)
         await this.view.open(file)
         this.view.addEventListener('load', this.#onLoad.bind(this))


### PR DESCRIPTION
This adds `<foliate-view smart>` that makes use of a `getDimensions()` asynchronous method that may be present in book sections. Currently, comic-book adds this method for JPG, PNG, GIF and WEBP pages as long as the `smart` attribute is set.

The purpose of smart spreads mode is to use the aspect ratio of a page to determine whether it should be placed in the `center` position of a spread rather than `left` or `right`. This allows double page spreads in comics to fill the entire viewport even when there is enough space for two pages.

Before:

![image](https://github.com/user-attachments/assets/be024680-0367-4085-adb4-928edd27da2e)

After:

![image](https://github.com/user-attachments/assets/05553062-8277-48e4-b685-8bcdbe8681f5)

I made this an attribute because of course there is a performance tradeoff. The getDimensions code in comic-book efficiently reads the dimensions of the pages from their headers without loading the entire file. However, all pages must still be extracted from the zip on load for this to work.

I'm not caching the pages themselves because I want low memory devices to be able to free up the memory used by each page when loading the next one during the dimensions extraction.