### PR TITLE
Add custom event for loading manifest item

### DIFF
--- a/epub.js
+++ b/epub.js
@@ -705,7 +705,6 @@ class Loader {
     #cache = new Map()
     #children = new Map()
     #refCount = new Map()
-    allowScript = false
     eventTarget = new EventTarget()
     constructor({ loadText, loadBlob, resources }) {
         this.loadText = loadText
@@ -764,7 +763,11 @@ class Loader {
         const { href, mediaType } = item
 
         const isScript = MIME.JS.test(item.mediaType)
-        if (isScript && !this.allowScript) return null
+        const detail = { type: mediaType, isScript, allow: true}
+        const event = new CustomEvent('load', { detail })
+        this.eventTarget.dispatchEvent(event)
+        const allow = await event.detail.allow
+        if (!allow) return null
 
         const parent = parents.at(-1)
         if (this.#cache.has(href)) return this.ref(href, parent)


### PR DESCRIPTION
In cases where JavaScript is needed to dynamically adjust the document layout, as discussed in [Readest issue #1278](https://github.com/readest/readest/issues/1278), the allowScript option is disabled by default. However, enabling it should be reasonably safe in well-sandboxed environments such as web browsers, iOS, Android, or native frameworks with sandboxed WebViews like [Tauri](https://tauri.app/security/).