### PR TITLE
Fix blocked animate when running in background

### DIFF
--- a/paginator.js
+++ b/paginator.js
@@ -19,11 +19,19 @@ const easeOutQuad = x => 1 - (1 - x) * (1 - x)
 const animate = (a, b, duration, ease, render) => new Promise(resolve => {
     let start
     const step = now => {
+        if (document.hidden) {
+            render(lerp(a, b, 1))
+            return resolve()
+        }
         start ??= now
         const fraction = Math.min(1, (now - start) / duration)
         render(lerp(a, b, ease(fraction)))
         if (fraction < 1) requestAnimationFrame(step)
         else resolve()
+    }
+    if (document.hidden) {
+        render(lerp(a, b, 1))
+        return resolve()
     }
     requestAnimationFrame(step)
 })


### PR DESCRIPTION
Otherwise `animate` will get stuck on Android and iOS when app is in background.