### PR TITLE
Fixed multibyte characters in MOBI fragment selectors

### DIFF
--- a/mobi.js
+++ b/mobi.js
@@ -1142,7 +1142,7 @@ class KF8 {
 
             const offsets = this.#fragmentOffsets.get(frag.index)
             if (offsets) for (const offset of offsets) {
-                const str = this.mobi.decode(fragRaw).slice(offset)
+                const str = this.mobi.decode(fragRaw.slice(offset))
                 const selector = getFragmentSelector(str)
                 this.#setFragmentSelector(frag.index, offset, selector)
             }


### PR DESCRIPTION
For Chinese/CJK text, multibyte character offsets were being incorrectly used as bytes offsets after decoding.
This should fix https://github.com/readest/readest/issues/1525.