### PR TITLE
Fix null error related to the behavior of ResizeObserver on Firefox & Safari

### DIFF
--- a/paginator.js
+++ b/paginator.js
@@ -360,6 +360,7 @@ class View {
         }
     }
     expand() {
+        if (!this.document) return;
         const { documentElement } = this.document
         if (this.#column) {
             const side = this.#vertical ? 'height' : 'width'


### PR DESCRIPTION
This PR fixes an issue which exists on Firefox and Safari which throws a null error whenever the `foliate-view` element is destroyed. I assume this happens because these browsers don't automatically clean up the ResizeObserver callbacks once their underlying elements have been destroyed. Either way, adding a simple null check in `paginator.js`'s `expand()` method fixes the issue.