### PR TITLE
Fixed multibyte characters in MOBI fragment selectors

### DIFF
--- a/mobi.js
+++ b/mobi.js
@@ -1212,7 +1212,7 @@ class KF8 {
         const frag = frags.find(frag => frag.index === fid)
         const offset = skel.offset + skel.length + frag.offset
         const fragRaw = await this.loadRaw(offset, offset + frag.length)
-        const str = this.mobi.decode(fragRaw).slice(off)
+        const str = this.mobi.decode(fragRaw.slice(off))
         const selector = getFragmentSelector(str)
         this.#setFragmentSelector(fid, off, selector)
         const anchor = doc => doc.querySelector(selector)


### PR DESCRIPTION
This should have been included in #91, but was missed in the previous PR, so I’m adding it here.