### PR TITLE
Fix: selections inside FILTER_SKIP wrappers must preserve offsets

### DIFF
--- a/epubcfi.js
+++ b/epubcfi.js
@@ -258,7 +258,11 @@ const partsToNode = (node, parts, filter) => {
 }
 
 const nodeToParts = (node, offset, filter) => {
-    const { parentNode, id } = node
+    let { id, parentNode } = node
+    while (filter && parentNode
+        && parentNode !== node.ownerDocument.documentElement
+        && filter(parentNode) === NodeFilter.FILTER_SKIP)
+            parentNode = parentNode.parentNode
     const indexed = indexChildNodes(parentNode, filter)
     const index = indexed.findIndex(x =>
         Array.isArray(x) ? x.some(x => x === node) : x === node)


### PR DESCRIPTION
Fixes: https://github.com/johnfactotum/foliate-js/issues/100

**Before**
https://jsfiddle.net/9mo8j67g/1/
<img width="297" height="148" alt="image" src="https://github.com/user-attachments/assets/d187b972-0c22-4fb2-9f38-00bb08aa28f2" />

**After**
https://jsfiddle.net/9mo8j67g/2/
<img width="320" height="150" alt="image" src="https://github.com/user-attachments/assets/179542df-b7b4-4add-820a-5f43aa3e4974" />
