### PR TITLE
Update pdf.js import path to resolve build errors

### DIFF
--- a/pdf.js
+++ b/pdf.js
@@ -1,4 +1,4 @@
-const pdfjsPath = path => new URL(`vendor/pdfjs/${path}`, import.meta.url).toString()
+const pdfjsPath = (path: string) => new URL(`./vendor/pdfjs/${path}`, import.meta.url).toString()
 
 import './vendor/pdfjs/pdf.mjs'
 const pdfjsLib = globalThis.pdfjsLib


### PR DESCRIPTION
Some build errors are caused by incorrect import paths in pdf.js. This fix updates the import path in said file to fix those errors.