### PR TITLE
Add pageBreakSource metadata property to epubs

### DIFF
--- a/epub.js
+++ b/epub.js
@@ -284,6 +284,7 @@ const getMetadata = opf => {
         altIdentifier: dc.identifier?.map(makeAltIdentifier),
         source: dc.source?.map(makeAltIdentifier), // NOTE: not in webpub schema
         rights: one(dc.rights), // NOTE: not in webpub schema
+        pageBreakSource: one(properties['pageBreakSource']), // NOTE: not in webpub schema
     }
     const remapContributor = defaultKey => x => {
         const keys = new Set(x.role?.map(role => RELATORS[role] ?? defaultKey))


### PR DESCRIPTION
This pull request adds the pageBreakSource property to epubs's exposed metadata (cfr. https://www.w3.org/publishing/a11y/page-source-id/). It's a &lt;meta&gt; property that clarifies the source of the optional page list of the epub (usually with the ISBN of a paper book).