### PR TITLE
Enable cfi filter usage for epubs

### DIFF
--- a/epub.js
+++ b/epub.js
@@ -1,4 +1,4 @@
-import * as CFI from './epubcfi.js'
+import * as defaultCFI from './epubcfi.js'
 
 const NS = {
     CONTAINER: 'urn:oasis:names:tc:opendocument:xmlns:container',
@@ -631,8 +631,9 @@ class Encryption {
 }
 
 class Resources {
-    constructor({ opf, resolveHref }) {
+    constructor({ opf, resolveHref, CFI }) {
         this.opf = opf
+        this.CFI = CFI
         const { $, $$, $$$ } = childGetter(opf, NS.OPF)
 
         const $manifest = $(opf.documentElement, 'manifest')
@@ -674,7 +675,7 @@ class Resources {
             ?? this.getItemByHref(this.guide
                 ?.find(ref => ref.type.includes('cover'))?.href)
 
-        this.cfis = CFI.fromElements($$itemref)
+        this.cfis = this.CFI.fromElements($$itemref)
     }
     getItemByID(id) {
         return this.manifestById.get(id)
@@ -686,19 +687,19 @@ class Resources {
         return this.manifest.find(item => item.properties?.includes(prop))
     }
     resolveCFI(cfi) {
-        const parts = CFI.parse(cfi)
+        const parts = this.CFI.parse(cfi)
         const top = (parts.parent ?? parts).shift()
-        let $itemref = CFI.toElement(this.opf, top)
+        let $itemref = this.CFI.toElement(this.opf, top)
         // make sure it's an idref; if not, try again without the ID assertion
         // mainly because Epub.js used to generate wrong ID assertions
         // https://github.com/futurepress/epub.js/issues/1236
         if ($itemref && $itemref.nodeName !== 'idref') {
             top.at(-1).id = null
-            $itemref = CFI.toElement(this.opf, top)
+            $itemref = this.CFI.toElement(this.opf, top)
         }
         const idref = $itemref?.getAttribute('idref')
         const index = this.spine.findIndex(item => item.idref === idref)
-        const anchor = doc => CFI.toRange(doc, parts)
+        const anchor = doc => this.CFI.toRange(doc, parts)
         return { index, anchor }
     }
 }
@@ -931,6 +932,7 @@ const getDisplayOptions = doc => {
 
 export class EPUB {
     parser = new DOMParser()
+    CFI = defaultCFI
     #loader
     #encryption
     constructor({ loadText, loadBlob, getSize, sha1 }) {
@@ -948,7 +950,8 @@ export class EPUB {
 ${doc.querySelector('parsererror').innerText}`)
         return doc
     }
-    async init() {
+    async init({ CFI } = {}) {
+        if (CFI) this.CFI = CFI
         const $container = await this.#loadXML('META-INF/container.xml')
         if (!$container) throw new Error('Failed to load container file')
 
@@ -967,6 +970,7 @@ ${doc.querySelector('parsererror').innerText}`)
 
         this.resources = new Resources({
             opf,
+            CFI: this.CFI,
             resolveHref: url => resolveURL(url, opfPath),
         })
         this.#loader = new Loader({

--- a/epub.js
+++ b/epub.js
@@ -1,5 +1,3 @@
-import * as defaultCFI from './epubcfi.js'
-
 const NS = {
     CONTAINER: 'urn:oasis:names:tc:opendocument:xmlns:container',
     XHTML: 'http://www.w3.org/1999/xhtml',
@@ -932,7 +930,7 @@ const getDisplayOptions = doc => {
 
 export class EPUB {
     parser = new DOMParser()
-    CFI = defaultCFI
+    CFI
     #loader
     #encryption
     constructor({ loadText, loadBlob, getSize, sha1 }) {
@@ -951,7 +949,7 @@ ${doc.querySelector('parsererror').innerText}`)
         return doc
     }
     async init({ CFI } = {}) {
-        if (CFI) this.CFI = CFI
+        this.CFI = CFI ?? await import('./epubcfi.js')
         const $container = await this.#loadXML('META-INF/container.xml')
         if (!$container) throw new Error('Failed to load container file')
 

--- a/view.js
+++ b/view.js
@@ -1,4 +1,3 @@
-import * as defaultCFI from './epubcfi.js'
 import { TOCProgress, SectionProgress } from './progress.js'
 import { Overlayer } from './overlayer.js'
 import { textWalker } from './text-walker.js'
@@ -221,7 +220,7 @@ export class View extends HTMLElement {
     isFixedLayout = false
     lastLocation
     history = new History()
-    CFI = defaultCFI
+    CFI
     constructor() {
         super()
         this.history.addEventListener('popstate', ({ detail }) => {
@@ -230,7 +229,7 @@ export class View extends HTMLElement {
         })
     }
     async open(book, { CFI } = {}) {
-        if (CFI) this.CFI = CFI
+        this.CFI = CFI ?? await import('./epubcfi.js')
         if (typeof book === 'string'
         || typeof book.arrayBuffer === 'function'
         || book.isDirectory) book = await makeBook(book, { CFI: this.CFI })

--- a/view.js
+++ b/view.js
@@ -1,4 +1,4 @@
-import * as CFI from './epubcfi.js'
+import * as defaultCFI from './epubcfi.js'
 import { TOCProgress, SectionProgress } from './progress.js'
 import { Overlayer } from './overlayer.js'
 import { textWalker } from './text-walker.js'
@@ -76,13 +76,13 @@ const fetchFile = async url => {
     return new File([await res.blob()], new URL(res.url).pathname)
 }
 
-export const makeBook = async file => {
+export const makeBook = async (file, opts) => {
     if (typeof file === 'string') file = await fetchFile(file)
     let book
     if (file.isDirectory) {
         const loader = await makeDirectoryLoader(file)
         const { EPUB } = await import('./epub.js')
-        book = await new EPUB(loader).init()
+        book = await new EPUB(loader).init({ CFI: opts?.CFI })
     }
     else if (!file.size) throw new NotFoundError('File not found')
     else if (await isZip(file)) {
@@ -100,7 +100,7 @@ export const makeBook = async file => {
         }
         else {
             const { EPUB } = await import('./epub.js')
-            book = await new EPUB(loader).init()
+            book = await new EPUB(loader).init({ CFI: opts?.CFI })
         }
     }
     else if (await isPDF(file)) {
@@ -221,6 +221,7 @@ export class View extends HTMLElement {
     isFixedLayout = false
     lastLocation
     history = new History()
+    CFI = defaultCFI
     constructor() {
         super()
         this.history.addEventListener('popstate', ({ detail }) => {
@@ -228,10 +229,11 @@ export class View extends HTMLElement {
             this.renderer.goTo(resolved)
         })
     }
-    async open(book) {
+    async open(book, { CFI } = {}) {
+        if (CFI) this.CFI = CFI
         if (typeof book === 'string'
         || typeof book.arrayBuffer === 'function'
-        || book.isDirectory) book = await makeBook(book)
+        || book.isDirectory) book = await makeBook(book, { CFI: this.CFI })
         this.book = book
         this.language = languageInfo(book.metadata?.language)
 
@@ -427,17 +429,17 @@ export class View extends HTMLElement {
         }
     }
     getCFI(index, range) {
-        const baseCFI = this.book.sections[index].cfi ?? CFI.fake.fromIndex(index)
+        const baseCFI = this.book.sections[index].cfi ?? this.CFI.fake.fromIndex(index)
         if (!range) return baseCFI
-        return CFI.joinIndir(baseCFI, CFI.fromRange(range))
+        return this.CFI.joinIndir(baseCFI, this.CFI.fromRange(range))
     }
     resolveCFI(cfi) {
         if (this.book.resolveCFI)
             return this.book.resolveCFI(cfi)
         else {
-            const parts = CFI.parse(cfi)
-            const index = CFI.fake.toIndex((parts.parent ?? parts).shift())
-            const anchor = doc => CFI.toRange(doc, parts)
+            const parts = this.CFI.parse(cfi)
+            const index = this.CFI.fake.toIndex((parts.parent ?? parts).shift())
+            const anchor = doc => this.CFI.toRange(doc, parts)
             return { index, anchor }
         }
     }
@@ -448,7 +450,7 @@ export class View extends HTMLElement {
                 const [index, anchor] = this.#sectionProgress.getSection(target.fraction)
                 return { index, anchor }
             }
-            if (CFI.isCFI.test(target)) return this.resolveCFI(target)
+            if (this.CFI.isCFI.test(target)) return this.resolveCFI(target)
             return this.book.resolveHref(target)
         } catch (e) {
             console.error(e)


### PR DESCRIPTION
This pull request adds the possibility to pass an optional cfi parser filter to the `resolveCFI` methods in `epub.js` and to `toElement` and `fromElements` functions in `epubcfi.js`.