### PR TITLE
Add draw options for search matches

### DIFF
--- a/view.js
+++ b/view.js
@@ -216,6 +216,8 @@ export class View extends HTMLElement {
     #tocProgress
     #pageProgress
     #searchResults = new Map()
+    #searchDraw
+    #searchDrawOptions
     #cursorAutohider = new CursorAutohider(this, () =>
         this.hasAttribute('autohide-cursor'))
     isFixedLayout = false
@@ -376,7 +378,7 @@ export class View extends HTMLElement {
                     return
                 }
                 const range = doc ? anchor(doc) : anchor
-                overlayer.add(value, range, Overlayer.outline)
+                overlayer.add(value, range, this.#searchDraw, this.#searchDrawOptions)
             }
             return
         }
@@ -539,6 +541,8 @@ export class View extends HTMLElement {
     }
     async * search(opts) {
         this.clearSearch()
+        this.#searchDraw = opts.draw ?? Overlayer.outline
+        this.#searchDrawOptions = opts.drawOptions
         const { searchMatcher } = await import('./search.js')
         const { query, index } = opts
         const matcher = searchMatcher(textWalker,


### PR DESCRIPTION
Allows setting draw options for search match annotations. No change to existing behavior when omitted.