### PR TITLE
fix(opds): align mapping with OPDS 2.0 WebPub properties, support OPD…

### DIFF
--- a/opds.js
+++ b/opds.js
@@ -53,7 +53,7 @@ const groupByArray = (arr, f) => {
 
 // https://www.rfc-editor.org/rfc/rfc7231#section-3.1.1
 const parseMediaType = str => {
-    if (!str) return null
+    if (!str) return
     const [mediaType, ...ps] = str.split(/ *; */)
     return {
         mediaType: mediaType.toLowerCase(),
@@ -74,7 +74,7 @@ export const isOPDSCatalog = str => {
 
 // ignore the namespace if it doesn't appear in document at all
 const useNS = (doc, ns) =>
-    doc.lookupNamespaceURI(null) === ns || doc.lookupPrefix(ns) ? ns : null
+    doc.lookupNamespaceURI(null) === ns || doc.lookupPrefix(ns) ? ns : undefined
 
 const filterNS = ns => ns
     ? name => el => el.namespaceURI === ns && el.localName === name
@@ -94,7 +94,7 @@ const getContent = el => {
 
 const getTextContent = el => {
     const content = getContent(el)
-    if (content?.type === 'text') return content?.value
+    if (content?.type === 'text') return content.value
 }
 
 const getSummary = (a, b) => getTextContent(a) ?? getTextContent(b)
@@ -106,13 +106,13 @@ const getDirectChildren = (el, ns, localName, tagName) => {
         (
             (node.namespaceURI === ns && node.localName === localName) ||
             (node.tagName === tagName)
-        )
+        ),
     )
 }
 
 const getPrice = link => {
     const prices = getDirectChildren(link, NS.OPDS, 'price', 'opds:price')
-    if (!prices.length) return null
+    if (!prices.length) return
     const parsed = prices.map(price => ({
         currency: price.getAttribute('currencycode'),
         value: parseFloat(price.textContent),
@@ -135,61 +135,45 @@ const getIndirectAcquisition = el => {
 }
 
 const getLink = link => {
-    const obj = {
-        rel: link.getAttribute('rel')?.split(/ +/),
-        href: link.getAttribute('href'),
-        type: link.getAttribute('type'),
-        title: link.getAttribute('title'),
-        properties: {},
-    }
+    const relAttr = link.getAttribute('rel')
+    const rel = relAttr ? relAttr.split(/ +/) : undefined
 
-    // --- Prices & Indirect Acquisitions ---
-    const price = getPrice(link)
-    if (price) obj.properties.price = price
-
-    const indirectAcquisition = getIndirectAcquisition(link)
-    if (indirectAcquisition.length) obj.properties.indirectAcquisition = indirectAcquisition
-
-    // --- Facet Grouping ---
-    const facetGroup = link.getAttributeNS(NS.OPDS, 'facetGroup') || link.getAttribute('opds:facetGroup')
-    if (facetGroup) obj[FACET_GROUP] = facetGroup
+    const isAcquisition = rel?.some(r => r.startsWith(REL.ACQ) || r === 'preview')
+    const isStream = rel?.includes(REL.STREAM)
+    const isFacet = rel?.includes(REL.FACET)
 
     // Map OPDS 1.x active facets to OPDS 2.0 "self" link
     const activeFacet = link.getAttributeNS(NS.OPDS, 'activeFacet') || link.getAttribute('opds:activeFacet')
-    if (activeFacet === 'true') {
-        obj.rel = [obj.rel ?? []].flat().concat('self')
-    }
+    const mappedRel = activeFacet === 'true' ? [rel ?? []].flat().concat('self') : rel
 
-    // --- Pagination / Facet Counters ---
     // Maps OPDS 1.x thr:count seamlessly to OPDS 2.0 properties.numberOfItems
     const thrCount = link.getAttributeNS(NS.THR, 'count') || link.getAttribute('thr:count')
+    // Support for systems that incorrectly use standard `count` for facet hints
     const fallbackCount = link.getAttribute('count')
-    const isStream = obj.rel?.includes(REL.STREAM)
-
-    if (thrCount != null) {
-        obj.properties.numberOfItems = Number(thrCount)
-    } else if (!isStream && fallbackCount != null) {
-        // Support for systems that incorrectly use standard `count` for facet hints
-        obj.properties.numberOfItems = Number(fallbackCount)
-    }
 
     // --- OPDS-PSE Extensions ---
-    // Kept explicitly inside properties to map to OPDS 2.x standard extension mechanism
     const pseCount = link.getAttributeNS(NS.PSE, 'count') || link.getAttribute('pse:count')
-    if (pseCount != null) {
-        obj.properties['pse:count'] = Number(pseCount)
-    } else if (isStream && fallbackCount != null) {
-        obj.properties['pse:count'] = Number(fallbackCount)
+    const pseLastRead = link.getAttributeNS(NS.PSE, 'lastRead') || link.getAttribute('pse:lastRead')
+    const pseLastReadDate = link.getAttributeNS(NS.PSE, 'lastReadDate') || link.getAttribute('pse:lastReadDate')
+
+    const obj = {
+        rel: mappedRel,
+        href: link.getAttribute('href'),
+        type: link.getAttribute('type'),
+        title: link.getAttribute('title'),
+        // --- Facet Grouping ---
+        [FACET_GROUP]: link.getAttributeNS(NS.OPDS, 'facetGroup') || link.getAttribute('opds:facetGroup'),
+        properties: {
+            price: (isAcquisition || isStream) ? getPrice(link) : undefined,
+            indirectAcquisition: (isAcquisition || isStream) ? getIndirectAcquisition(link) : [],
+            // --- Pagination / Facet Counters ---
+            numberOfItems: thrCount != null ? Number(thrCount) : (isFacet && fallbackCount != null) ? Number(fallbackCount) : undefined,
+            'pse:count': isStream ? Number(pseCount || fallbackCount) || undefined : undefined,
+            'pse:lastRead': isStream && pseLastRead != null ? Number(pseLastRead) : undefined,
+            'pse:lastReadDate': isStream ? pseLastReadDate : undefined,
+        },
     }
 
-    const pseLastRead = link.getAttributeNS(NS.PSE, 'lastRead') || link.getAttribute('pse:lastRead')
-    if (pseLastRead != null) obj.properties['pse:lastRead'] = Number(pseLastRead)
-
-    const pseLastReadDate = link.getAttributeNS(NS.PSE, 'lastReadDate') || link.getAttribute('pse:lastReadDate')
-    if (pseLastReadDate != null) obj.properties['pse:lastReadDate'] = pseLastReadDate
-    // ---------------------------
-
-    // Clean up empty properties
     if (Object.keys(obj.properties).length === 0) delete obj.properties
 
     return obj
@@ -221,8 +205,7 @@ export const getPublication = entry => {
             author: children.filter(filter('author')).map(getPerson),
             contributor: children.filter(filter('contributor')).map(getPerson),
             publisher: children.find(filterDC('publisher'))?.textContent,
-            published: (children.find(filterDCTERMS('issued'))
-                ?? children.find(filterDC('date')))?.textContent,
+            published: (children.find(filterDCTERMS('issued')) ?? children.find(filterDC('date')))?.textContent,
             language: children.find(filterDC('language'))?.textContent,
             identifier: children.find(filterDC('identifier'))?.textContent,
             subject: children.filter(filter('category')).map(category => ({
@@ -231,8 +214,7 @@ export const getPublication = entry => {
                 scheme: category.getAttribute('scheme'),
             })),
             rights: children.find(filter('rights'))?.textContent ?? '',
-            [SYMBOL.CONTENT]: getContent(children.find(filter('content'))
-                ?? children.find(filter('summary'))),
+            [SYMBOL.CONTENT]: getContent(children.find(filter('content')) ?? children.find(filter('summary'))),
         },
         links,
         images: REL.COVER.concat(REL.THUMBNAIL)
@@ -251,7 +233,7 @@ export const getFeed = doc => {
     const filterFH = filterNS(NS.FH)
     const filterOS = filterNS(NS.OS)
 
-    const groupedItems = new Map([[null, []]])
+    const groupedItems = new Map([[undefined, []]])
     const groupLinkMap = new Map()
     for (const entry of entries) {
         const children = Array.from(entry.children)
@@ -262,7 +244,7 @@ export const getFeed = doc => {
 
         const groupLinks = linksByRel.get(REL.GROUP) ?? linksByRel.get('collection')
         const groupLink = groupLinks?.length
-            ? groupLinks.find(link => groupedItems.has(link.href)) ?? groupLinks[0] : null
+            ? groupLinks.find(link => groupedItems.has(link.href)) ?? groupLinks[0] : undefined
         if (groupLink && !groupLinkMap.has(groupLink.href))
             groupLinkMap.set(groupLink.href, groupLink)
 
@@ -274,13 +256,13 @@ export const getFeed = doc => {
                     children.find(filter('content'))),
             })
 
-        const arr = groupedItems.get(groupLink?.href ?? null)
+        const arr = groupedItems.get(groupLink?.href)
         if (arr) arr.push(item)
         else groupedItems.set(groupLink.href, [item])
     }
     const [items, ...groups] = Array.from(groupedItems, ([key, items]) => {
         const itemsKey = items[0]?.metadata ? 'publications' : 'navigation'
-        if (key == null) return { [itemsKey]: items }
+        if (key === undefined) return { [itemsKey]: items }
         const link = groupLinkMap.get(key)
         return {
             metadata: {
@@ -292,39 +274,36 @@ export const getFeed = doc => {
         }
     })
 
-    const metadata = {
-        title: children.find(filter('title'))?.textContent,
-        subtitle: children.find(filter('subtitle'))?.textContent,
-    }
-
     // --- OPDS 2.0 Pagination (derived from OpenSearch / RFC 5005) ---
     const totalResults = children.find(filterOS('totalResults'))?.textContent
     const itemsPerPage = children.find(filterOS('itemsPerPage'))?.textContent
     const startIndex = children.find(filterOS('startIndex'))?.textContent
 
-    if (totalResults != null) metadata.numberOfItems = Number(totalResults)
-    if (itemsPerPage != null) metadata.itemsPerPage = Number(itemsPerPage)
+    let currentPage
     if (startIndex != null && itemsPerPage != null) {
         const start = Number(startIndex)
         const items = Number(itemsPerPage)
         // Resolves typical 1-based offset to a page number
-        metadata.currentPage = Math.floor((start > 0 ? start - 1 : 0) / items) + 1
+        currentPage = Math.floor((start > 0 ? start - 1 : 0) / items) + 1
     }
 
-    const isComplete = !!children.find(filterFH('complete'))
-    const isArchive = !!children.find(filterFH('archive'))
-    // ----------------------------------------------------------------
-
     return {
-        metadata,
+        metadata: {
+            title: children.find(filter('title'))?.textContent,
+            subtitle: children.find(filter('subtitle'))?.textContent,
+            numberOfItems: totalResults != null ? Number(totalResults) : undefined,
+            itemsPerPage: itemsPerPage != null ? Number(itemsPerPage) : undefined,
+            currentPage,
+        },
         links,
-        isComplete,
-        isArchive,
+        isComplete: !!children.find(filterFH('complete')),
+        isArchive: !!children.find(filterFH('archive')),
         ...items,
         groups,
         facets: Array.from(
             groupByArray(linksByRel.get(REL.FACET) ?? [], link => link[FACET_GROUP]),
-            ([facet, links]) => ({ metadata: { title: facet }, links })),
+            ([facet, links]) => ({ metadata: { title: facet }, links }),
+        ),
     }
 }
 
@@ -334,7 +313,7 @@ export const getSearch = async link => {
         metadata: {
             title: link.title,
         },
-        search: map => replace(link.href, map.get(null)),
+        search: map => replace(link.href, map.get(undefined)),
         params: Array.from(getVariables(link.href), name => ({ name })),
     }
 }
@@ -365,14 +344,14 @@ export const getOpenSearch = doc => {
             description: children.find(filter('Description'))?.textContent,
         },
         search: map => template.replace(regex, (_, prefix, param) => {
-            const namespace = prefix ? $url.lookupNamespaceURI(prefix) : null
-            const ns = namespace === defaultNS ? null : namespace
+            const namespace = prefix ? $url.lookupNamespaceURI(prefix) : undefined
+            const ns = namespace === defaultNS ? undefined : namespace
             const val = map.get(ns)?.get(param)
             return encodeURIComponent(val ? val : (!ns ? defaultMap.get(param) ?? '' : ''))
         }),
         params: Array.from(template.matchAll(regex), ([, prefix, param, optional]) => {
-            const namespace = prefix ? $url.lookupNamespaceURI(prefix) : null
-            const ns = namespace === defaultNS ? null : namespace
+            const namespace = prefix ? $url.lookupNamespaceURI(prefix) : undefined
+            const ns = namespace === defaultNS ? undefined : namespace
             return {
                 ns, name: param,
                 required: !optional,

--- a/opds.js
+++ b/opds.js
@@ -155,7 +155,7 @@ const getLink = link => {
     const pseLastRead = link.getAttributeNS(NS.PSE, 'lastRead') || link.getAttribute('pse:lastRead')
     const pseLastReadDate = link.getAttributeNS(NS.PSE, 'lastReadDate') || link.getAttribute('pse:lastReadDate')
 
-    const obj = {
+    return {
         rel: mappedRel,
         href: link.getAttribute('href') ?? undefined,
         type: link.getAttribute('type') ?? undefined,
@@ -172,10 +172,6 @@ const getLink = link => {
             'pse:lastReadDate': isStream ? pseLastReadDate ?? undefined : undefined,
         },
     }
-
-    if (Object.keys(obj.properties).length === 0) delete obj.properties
-
-    return obj
 }
 
 const getPerson = person => {

--- a/opds.js
+++ b/opds.js
@@ -4,6 +4,9 @@ const NS = {
     THR: 'http://purl.org/syndication/thread/1.0',
     DC: 'http://purl.org/dc/elements/1.1/',
     DCTERMS: 'http://purl.org/dc/terms/',
+    FH: 'http://purl.org/syndication/history/1.0',
+    PSE: 'http://vaemendis.net/opds-pse/ns',
+    OS: 'http://a9.com/-/spec/opensearch/1.1/',
 }
 
 const MIME = {
@@ -25,6 +28,7 @@ export const REL = {
         'http://opds-spec.org/thumbnail', // ManyBooks legacy, not in spec
         'x-stanza-cover-image-thumbnail', // Lexcycle Stanza legacy
     ],
+    STREAM: 'http://vaemendis.net/opds-pse/stream',
 }
 
 export const SYMBOL = {
@@ -95,18 +99,39 @@ const getTextContent = el => {
 
 const getSummary = (a, b) => getTextContent(a) ?? getTextContent(b)
 
+// Fetch only direct children to avoid polluting with nested deep indirect acquisitions
+const getDirectChildren = (el, ns, localName, tagName) => {
+    return Array.from(el.childNodes).filter(node =>
+        node.nodeType === 1 &&
+        (
+            (node.namespaceURI === ns && node.localName === localName) ||
+            (node.tagName === tagName)
+        )
+    )
+}
+
 const getPrice = link => {
-    const price = link.getElementsByTagNameNS(NS.OPDS, 'price')[0]
-    return price ? {
+    const prices = getDirectChildren(link, NS.OPDS, 'price', 'opds:price')
+    if (!prices.length) return null
+    const parsed = prices.map(price => ({
         currency: price.getAttribute('currencycode'),
-        value: price.textContent,
-    } : null
+        value: parseFloat(price.textContent),
+    }))
+    // Although OPDS 2.0 schema defines price as a single object, OPDS 1.x allows multiple.
+    // Returning an array ensures no data loss, or a single object if there's only one.
+    return parsed.length === 1 ? parsed[0] : parsed
 }
 
 const getIndirectAcquisition = el => {
-    const ia = el.getElementsByTagNameNS(NS.OPDS, 'indirectAcquisition')[0]
-    if (!ia) return []
-    return [{ type: ia.getAttribute('type') }, ...getIndirectAcquisition(ia)]
+    const ias = getDirectChildren(el, NS.OPDS, 'indirectAcquisition', 'opds:indirectAcquisition')
+    if (!ias.length) return []
+    return ias.map(ia => {
+        const type = ia.getAttribute('type')
+        const child = getIndirectAcquisition(ia)
+        const res = { type }
+        if (child.length > 0) res.child = child
+        return res
+    })
 }
 
 const getLink = link => {
@@ -115,15 +140,58 @@ const getLink = link => {
         href: link.getAttribute('href'),
         type: link.getAttribute('type'),
         title: link.getAttribute('title'),
-        properties: {
-            price: getPrice(link),
-            indirectAcquisition: getIndirectAcquisition(link),
-            numberOfItems: link.getAttributeNS(NS.THR, 'count'),
-        },
-        [FACET_GROUP]: link.getAttributeNS(NS.OPDS, 'facetGroup'),
+        properties: {},
     }
-    if (link.getAttributeNS(NS.OPDS, 'activeFacet') === 'true')
+
+    // --- Prices & Indirect Acquisitions ---
+    const price = getPrice(link)
+    if (price) obj.properties.price = price
+
+    const indirectAcquisition = getIndirectAcquisition(link)
+    if (indirectAcquisition.length) obj.properties.indirectAcquisition = indirectAcquisition
+
+    // --- Facet Grouping ---
+    const facetGroup = link.getAttributeNS(NS.OPDS, 'facetGroup') || link.getAttribute('opds:facetGroup')
+    if (facetGroup) obj[FACET_GROUP] = facetGroup
+
+    // Map OPDS 1.x active facets to OPDS 2.0 "self" link
+    const activeFacet = link.getAttributeNS(NS.OPDS, 'activeFacet') || link.getAttribute('opds:activeFacet')
+    if (activeFacet === 'true') {
         obj.rel = [obj.rel ?? []].flat().concat('self')
+    }
+
+    // --- Pagination / Facet Counters ---
+    // Maps OPDS 1.x thr:count seamlessly to OPDS 2.0 properties.numberOfItems
+    const thrCount = link.getAttributeNS(NS.THR, 'count') || link.getAttribute('thr:count')
+    const fallbackCount = link.getAttribute('count')
+    const isStream = obj.rel?.includes(REL.STREAM)
+
+    if (thrCount != null) {
+        obj.properties.numberOfItems = Number(thrCount)
+    } else if (!isStream && fallbackCount != null) {
+        // Support for systems that incorrectly use standard `count` for facet hints
+        obj.properties.numberOfItems = Number(fallbackCount)
+    }
+
+    // --- OPDS-PSE Extensions ---
+    // Kept explicitly inside properties to map to OPDS 2.x standard extension mechanism
+    const pseCount = link.getAttributeNS(NS.PSE, 'count') || link.getAttribute('pse:count')
+    if (pseCount != null) {
+        obj.properties['pse:count'] = Number(pseCount)
+    } else if (isStream && fallbackCount != null) {
+        obj.properties['pse:count'] = Number(fallbackCount)
+    }
+
+    const pseLastRead = link.getAttributeNS(NS.PSE, 'lastRead') || link.getAttribute('pse:lastRead')
+    if (pseLastRead != null) obj.properties['pse:lastRead'] = Number(pseLastRead)
+
+    const pseLastReadDate = link.getAttributeNS(NS.PSE, 'lastReadDate') || link.getAttribute('pse:lastReadDate')
+    if (pseLastReadDate != null) obj.properties['pse:lastReadDate'] = pseLastReadDate
+    // ---------------------------
+
+    // Clean up empty properties
+    if (Object.keys(obj.properties).length === 0) delete obj.properties
+
     return obj
 }
 
@@ -180,6 +248,9 @@ export const getFeed = doc => {
     const links = children.filter(filter('link')).map(getLink)
     const linksByRel = groupByArray(links, link => link.rel)
 
+    const filterFH = filterNS(NS.FH)
+    const filterOS = filterNS(NS.OS)
+
     const groupedItems = new Map([[null, []]])
     const groupLinkMap = new Map()
     for (const entry of entries) {
@@ -187,7 +258,7 @@ export const getFeed = doc => {
         const links = children.filter(filter('link')).map(getLink)
         const linksByRel = groupByArray(links, link => link.rel)
         const isPub = [...linksByRel.keys()]
-            .some(rel => rel?.startsWith(REL.ACQ) || rel === 'preview')
+            .some(rel => rel?.startsWith(REL.ACQ) || rel === 'preview' || rel === REL.STREAM)
 
         const groupLinks = linksByRel.get(REL.GROUP) ?? linksByRel.get('collection')
         const groupLink = groupLinks?.length
@@ -214,18 +285,41 @@ export const getFeed = doc => {
         return {
             metadata: {
                 title: link.title,
-                numberOfItems: link.properties.numberOfItems,
+                numberOfItems: link.properties?.numberOfItems,
             },
             links: [{ rel: 'self', href: link.href, type: link.type }],
             [itemsKey]: items,
         }
     })
+
+    const metadata = {
+        title: children.find(filter('title'))?.textContent,
+        subtitle: children.find(filter('subtitle'))?.textContent,
+    }
+
+    // --- OPDS 2.0 Pagination (derived from OpenSearch / RFC 5005) ---
+    const totalResults = children.find(filterOS('totalResults'))?.textContent
+    const itemsPerPage = children.find(filterOS('itemsPerPage'))?.textContent
+    const startIndex = children.find(filterOS('startIndex'))?.textContent
+
+    if (totalResults != null) metadata.numberOfItems = Number(totalResults)
+    if (itemsPerPage != null) metadata.itemsPerPage = Number(itemsPerPage)
+    if (startIndex != null && itemsPerPage != null) {
+        const start = Number(startIndex)
+        const items = Number(itemsPerPage)
+        // Resolves typical 1-based offset to a page number
+        metadata.currentPage = Math.floor((start > 0 ? start - 1 : 0) / items) + 1
+    }
+
+    const isComplete = !!children.find(filterFH('complete'))
+    const isArchive = !!children.find(filterFH('archive'))
+    // ----------------------------------------------------------------
+
     return {
-        metadata: {
-            title: children.find(filter('title'))?.textContent,
-            subtitle: children.find(filter('subtitle'))?.textContent,
-        },
+        metadata,
         links,
+        isComplete,
+        isArchive,
         ...items,
         groups,
         facets: Array.from(

--- a/opds.js
+++ b/opds.js
@@ -114,11 +114,10 @@ const getPrice = link => {
     const prices = getDirectChildren(link, NS.OPDS, 'price', 'opds:price')
     if (!prices.length) return
     const parsed = prices.map(price => ({
-        currency: price.getAttribute('currencycode'),
+        currency: price.getAttribute('currencycode') ?? undefined,
         value: parseFloat(price.textContent),
     }))
-    // Although OPDS 2.0 schema defines price as a single object, OPDS 1.x allows multiple.
-    // Returning an array ensures no data loss, or a single object if there's only one.
+    // OPDS 1.x allows multiple prices, OPDS 2.0 schema defines price as a single object
     return parsed.length === 1 ? parsed[0] : parsed
 }
 
@@ -127,11 +126,12 @@ const getIndirectAcquisition = el => {
     if (!ias.length) return []
     return ias.map(ia => {
         const type = ia.getAttribute('type')
-        const child = getIndirectAcquisition(ia)
-        const res = { type }
-        if (child.length > 0) res.child = child
-        return res
-    })
+        if (!type) return undefined
+        return {
+            type,
+            child: getIndirectAcquisition(ia),
+        }
+    }).filter(Boolean)
 }
 
 const getLink = link => {
@@ -158,19 +158,19 @@ const getLink = link => {
 
     const obj = {
         rel: mappedRel,
-        href: link.getAttribute('href'),
-        type: link.getAttribute('type'),
-        title: link.getAttribute('title'),
+        href: link.getAttribute('href') ?? undefined,
+        type: link.getAttribute('type') ?? undefined,
+        title: link.getAttribute('title') ?? undefined,
         // --- Facet Grouping ---
-        [FACET_GROUP]: link.getAttributeNS(NS.OPDS, 'facetGroup') || link.getAttribute('opds:facetGroup'),
+        [FACET_GROUP]: link.getAttributeNS(NS.OPDS, 'facetGroup') || link.getAttribute('opds:facetGroup') || undefined,
         properties: {
             price: (isAcquisition || isStream) ? getPrice(link) : undefined,
-            indirectAcquisition: (isAcquisition || isStream) ? getIndirectAcquisition(link) : [],
+            indirectAcquisition: (isAcquisition || isStream) ? getIndirectAcquisition(link) : undefined,
             // --- Pagination / Facet Counters ---
             numberOfItems: thrCount != null ? Number(thrCount) : (isFacet && fallbackCount != null) ? Number(fallbackCount) : undefined,
-            'pse:count': isStream ? Number(pseCount || fallbackCount) || undefined : undefined,
+            'pse:count': isStream && (pseCount ?? fallbackCount) != null ? Number(pseCount ?? fallbackCount) : undefined,
             'pse:lastRead': isStream && pseLastRead != null ? Number(pseLastRead) : undefined,
-            'pse:lastReadDate': isStream ? pseLastReadDate : undefined,
+            'pse:lastReadDate': isStream ? pseLastReadDate ?? undefined : undefined,
         },
     }
 
@@ -183,7 +183,7 @@ const getPerson = person => {
     const NS = person.namespaceURI
     const uri = person.getElementsByTagNameNS(NS, 'uri')[0]?.textContent
     return {
-        name: person.getElementsByTagNameNS(NS, 'name')[0]?.textContent ?? '',
+        name: person.getElementsByTagNameNS(NS, 'name')[0]?.textContent ?? undefined,
         links: uri ? [{ href: uri }] : [],
     }
 }
@@ -193,32 +193,29 @@ export const getPublication = entry => {
     const children = Array.from(entry.children)
     const filterDCEL = filterNS(NS.DC)
     const filterDCTERMS = filterNS(NS.DCTERMS)
-    const filterDC = x => {
-        const a = filterDCEL(x), b = filterDCTERMS(x)
-        return y => a(y) || b(y)
-    }
+    const filterDC = x => y => filterDCEL(x)(y) || filterDCTERMS(x)(y)
     const links = children.filter(filter('link')).map(getLink)
     const linksByRel = groupByArray(links, link => link.rel)
     return {
         metadata: {
-            title: children.find(filter('title'))?.textContent ?? '',
+            title: children.find(filter('title'))?.textContent ?? undefined,
             author: children.filter(filter('author')).map(getPerson),
             contributor: children.filter(filter('contributor')).map(getPerson),
-            publisher: children.find(filterDC('publisher'))?.textContent,
-            published: (children.find(filterDCTERMS('issued')) ?? children.find(filterDC('date')))?.textContent,
-            language: children.find(filterDC('language'))?.textContent,
-            identifier: children.find(filterDC('identifier'))?.textContent,
+            publisher: children.find(filterDC('publisher'))?.textContent ?? undefined,
+            published: (children.find(filterDCTERMS('issued')) ?? children.find(filterDC('date')))?.textContent ?? undefined,
+            language: children.find(filterDC('language'))?.textContent ?? undefined,
+            identifier: children.find(filterDC('identifier'))?.textContent ?? undefined,
             subject: children.filter(filter('category')).map(category => ({
-                name: category.getAttribute('label'),
-                code: category.getAttribute('term'),
-                scheme: category.getAttribute('scheme'),
+                name: category.getAttribute('label') ?? undefined,
+                code: category.getAttribute('term') ?? undefined,
+                scheme: category.getAttribute('scheme') ?? undefined,
             })),
-            rights: children.find(filter('rights'))?.textContent ?? '',
-            [SYMBOL.CONTENT]: getContent(children.find(filter('content')) ?? children.find(filter('summary'))),
+            rights: children.find(filter('rights'))?.textContent ?? undefined,
+            [SYMBOL.CONTENT]: getContent(children.find(filter('content')) ?? children.find(filter('summary'))) ?? undefined,
         },
         links,
         images: REL.COVER.concat(REL.THUMBNAIL)
-            .map(R => linksByRel.get(R)?.[0]).filter(x => x),
+            .map(R => linksByRel.get(R)?.[0]).filter(Boolean),
     }
 }
 
@@ -251,9 +248,9 @@ export const getFeed = doc => {
         const item = isPub
             ? getPublication(entry)
             : Object.assign(links.find(link => isOPDSCatalog(link.type)) ?? links[0] ?? {}, {
-                title: children.find(filter('title'))?.textContent,
+                title: children.find(filter('title'))?.textContent ?? undefined,
                 [SYMBOL.SUMMARY]: getSummary(children.find(filter('summary')),
-                    children.find(filter('content'))),
+                    children.find(filter('content'))) ?? undefined,
             })
 
         const arr = groupedItems.get(groupLink?.href)
@@ -289,20 +286,20 @@ export const getFeed = doc => {
 
     return {
         metadata: {
-            title: children.find(filter('title'))?.textContent,
-            subtitle: children.find(filter('subtitle'))?.textContent,
+            title: children.find(filter('title'))?.textContent ?? undefined,
+            subtitle: children.find(filter('subtitle'))?.textContent ?? undefined,
             numberOfItems: totalResults != null ? Number(totalResults) : undefined,
             itemsPerPage: itemsPerPage != null ? Number(itemsPerPage) : undefined,
             currentPage,
         },
         links,
-        isComplete: !!children.find(filterFH('complete')),
-        isArchive: !!children.find(filterFH('archive')),
+        isComplete: !!children.find(filterFH('complete')) || undefined,
+        isArchive: !!children.find(filterFH('archive')) || undefined,
         ...items,
-        groups,
+        groups: groups.length ? groups : undefined,
         facets: Array.from(
             groupByArray(linksByRel.get(REL.FACET) ?? [], link => link[FACET_GROUP]),
-            ([facet, links]) => ({ metadata: { title: facet }, links }),
+            ([facet, links]) => ({ metadata: { title: facet ?? undefined }, links }),
         ),
     }
 }
@@ -311,7 +308,7 @@ export const getSearch = async link => {
     const { replace, getVariables } = await import('./uri-template.js')
     return {
         metadata: {
-            title: link.title,
+            title: link.title ?? undefined,
         },
         search: map => replace(link.href, map.get(undefined)),
         params: Array.from(getVariables(link.href), name => ({ name })),
@@ -340,22 +337,23 @@ export const getOpenSearch = doc => {
     const template = $url.getAttribute('template')
     return {
         metadata: {
-            title: (children.find(filter('LongName')) ?? children.find(filter('ShortName')))?.textContent,
-            description: children.find(filter('Description'))?.textContent,
+            title: (children.find(filter('LongName')) ?? children.find(filter('ShortName')))?.textContent ?? undefined,
+            description: children.find(filter('Description'))?.textContent ?? undefined,
         },
         search: map => template.replace(regex, (_, prefix, param) => {
             const namespace = prefix ? $url.lookupNamespaceURI(prefix) : undefined
             const ns = namespace === defaultNS ? undefined : namespace
             const val = map.get(ns)?.get(param)
-            return encodeURIComponent(val ? val : (!ns ? defaultMap.get(param) ?? '' : ''))
+            return encodeURIComponent(val ?? (!ns ? defaultMap.get(param) ?? '' : ''))
         }),
         params: Array.from(template.matchAll(regex), ([, prefix, param, optional]) => {
             const namespace = prefix ? $url.lookupNamespaceURI(prefix) : undefined
             const ns = namespace === defaultNS ? undefined : namespace
             return {
-                ns, name: param,
+                ns,
+                name: param,
                 required: !optional,
-                value: ns && ns !== defaultNS ? '' : defaultMap.get(param) ?? '',
+                value: ns && ns !== defaultNS ? undefined : (defaultMap.get(param) ?? undefined),
             }
         }),
     }

--- a/opds.js
+++ b/opds.js
@@ -40,12 +40,15 @@ const FACET_GROUP = Symbol('facetGroup')
 
 const groupByArray = (arr, f) => {
     const map = new Map()
-    if (arr) for (const el of arr) {
-        const keys = f(el)
-        for (const key of [keys].flat()) {
-            const group = map.get(key)
-            if (group) group.push(el)
-            else map.set(key, [el])
+    if (arr) {
+        for (const el of arr) {
+            const keys = f(el)
+            const keyArray = keys == null ? [] : (Array.isArray(keys) ? keys : [keys])
+            for (const key of keyArray) {
+                const group = map.get(key)
+                if (group) group.push(el)
+                else map.set(key, [el])
+            }
         }
     }
     return map
@@ -55,12 +58,16 @@ const groupByArray = (arr, f) => {
 const parseMediaType = str => {
     if (!str) return
     const [mediaType, ...ps] = str.split(/ *; */)
+    if (!mediaType) return
     return {
         mediaType: mediaType.toLowerCase(),
-        parameters: Object.fromEntries(ps.map(p => {
+        parameters: ps.reduce((acc, p) => {
             const [name, val] = p.split('=')
-            return [name.toLowerCase(), val?.replace(/(^"|"$)/g, '')]
-        })),
+            if (name) {
+                acc[name.toLowerCase()] = val?.replace(/(^"|"$)/g, '')
+            }
+            return acc
+        }, {}),
     }
 }
 
@@ -106,17 +113,25 @@ const getDirectChildren = (el, ns, localName, tagName) => {
         (
             (node.namespaceURI === ns && node.localName === localName) ||
             (node.tagName === tagName)
-        ),
+        )
     )
 }
 
 const getPrice = link => {
     const prices = getDirectChildren(link, NS.OPDS, 'price', 'opds:price')
     if (!prices.length) return
-    const parsed = prices.map(price => ({
-        currency: price.getAttribute('currencycode') ?? undefined,
-        value: parseFloat(price.textContent),
-    }))
+    const parsed = prices.reduce((acc, price) => {
+        const value = parseFloat(price.textContent)
+        if (!isNaN(value)) {
+            acc.push({
+                currency: price.getAttribute('currencycode') ?? undefined,
+                value,
+            })
+        }
+        return acc
+    }, [])
+
+    if (!parsed.length) return
     // OPDS 1.x allows multiple prices, OPDS 2.0 schema defines price as a single object
     return parsed.length === 1 ? parsed[0] : parsed
 }
@@ -124,14 +139,16 @@ const getPrice = link => {
 const getIndirectAcquisition = el => {
     const ias = getDirectChildren(el, NS.OPDS, 'indirectAcquisition', 'opds:indirectAcquisition')
     if (!ias.length) return []
-    return ias.map(ia => {
+    return ias.reduce((acc, ia) => {
         const type = ia.getAttribute('type')
-        if (!type) return undefined
-        return {
-            type,
-            child: getIndirectAcquisition(ia),
+        if (type) {
+            acc.push({
+                type,
+                child: getIndirectAcquisition(ia),
+            })
         }
-    }).filter(Boolean)
+        return acc
+    }, [])
 }
 
 const getLink = link => {
@@ -161,7 +178,7 @@ const getLink = link => {
         type: link.getAttribute('type') ?? undefined,
         title: link.getAttribute('title') ?? undefined,
         // --- Facet Grouping ---
-        [FACET_GROUP]: link.getAttributeNS(NS.OPDS, 'facetGroup') || link.getAttribute('opds:facetGroup') || undefined,
+        [FACET_GROUP]: link.getAttributeNS(NS.OPDS, 'facetGroup') || link.getAttribute('opds:facetGroup') ?? undefined,
         properties: {
             price: (isAcquisition || isStream) ? getPrice(link) : undefined,
             indirectAcquisition: (isAcquisition || isStream) ? getIndirectAcquisition(link) : undefined,
@@ -231,14 +248,15 @@ export const getFeed = doc => {
         const children = Array.from(entry.children)
         const links = children.filter(filter('link')).map(getLink)
         const linksByRel = groupByArray(links, link => link.rel)
-        const isPub = [...linksByRel.keys()]
+        const isPub = Array.from(linksByRel.keys())
             .some(rel => rel?.startsWith(REL.ACQ) || rel === 'preview' || rel === REL.STREAM)
 
         const groupLinks = linksByRel.get(REL.GROUP) ?? linksByRel.get('collection')
         const groupLink = groupLinks?.length
             ? groupLinks.find(link => groupedItems.has(link.href)) ?? groupLinks[0] : undefined
-        if (groupLink && !groupLinkMap.has(groupLink.href))
+        if (groupLink?.href && !groupLinkMap.has(groupLink.href)) {
             groupLinkMap.set(groupLink.href, groupLink)
+        }
 
         const item = isPub
             ? getPublication(entry)
@@ -258,10 +276,10 @@ export const getFeed = doc => {
         const link = groupLinkMap.get(key)
         return {
             metadata: {
-                title: link.title,
-                numberOfItems: link.properties?.numberOfItems,
+                title: link?.title,
+                numberOfItems: link?.properties?.numberOfItems,
             },
-            links: [{ rel: 'self', href: link.href, type: link.type }],
+            links: [{ rel: 'self', href: link?.href, type: link?.type }],
             [itemsKey]: items,
         }
     })
@@ -294,19 +312,20 @@ export const getFeed = doc => {
         groups: groups.length ? groups : undefined,
         facets: Array.from(
             groupByArray(linksByRel.get(REL.FACET) ?? [], link => link[FACET_GROUP]),
-            ([facet, links]) => ({ metadata: { title: facet ?? undefined }, links }),
+            ([facet, links]) => ({ metadata: { title: facet ?? undefined }, links })
         ),
     }
 }
 
 export const getSearch = async link => {
     const { replace, getVariables } = await import('./uri-template.js')
+    const href = link.href || ''
     return {
         metadata: {
             title: link.title ?? undefined,
         },
-        search: map => replace(link.href, map.get(undefined)),
-        params: Array.from(getVariables(link.href), name => ({ name })),
+        search: map => replace(href, map.get(undefined)),
+        params: Array.from(getVariables(href), name => ({ name })),
     }
 }
 
@@ -329,7 +348,7 @@ export const getOpenSearch = doc => {
         ['outputEncoding', 'UTF-8'],
     ])
 
-    const template = $url.getAttribute('template')
+    const template = $url.getAttribute('template') || ''
     return {
         metadata: {
             title: (children.find(filter('LongName')) ?? children.find(filter('ShortName')))?.textContent ?? undefined,
@@ -346,9 +365,9 @@ export const getOpenSearch = doc => {
             const ns = namespace === defaultNS ? undefined : namespace
             return {
                 ns,
-                name: param,
+                name: param, // (.+?) ensures `param` is non-empty
                 required: !optional,
-                value: ns && ns !== defaultNS ? undefined : (defaultMap.get(param) ?? undefined),
+                value: ns && ns !== defaultNS ? undefined : defaultMap.get(param) ?? undefined,
             }
         }),
     }

--- a/opds.js
+++ b/opds.js
@@ -140,7 +140,6 @@ const getLink = link => {
 
     const isAcquisition = rel?.some(r => r.startsWith(REL.ACQ) || r === 'preview')
     const isStream = rel?.includes(REL.STREAM)
-    const isFacet = rel?.includes(REL.FACET)
 
     // Map OPDS 1.x active facets to OPDS 2.0 "self" link
     const activeFacet = link.getAttributeNS(NS.OPDS, 'activeFacet') || link.getAttribute('opds:activeFacet')
@@ -167,7 +166,7 @@ const getLink = link => {
             price: (isAcquisition || isStream) ? getPrice(link) : undefined,
             indirectAcquisition: (isAcquisition || isStream) ? getIndirectAcquisition(link) : undefined,
             // --- Pagination / Facet Counters ---
-            numberOfItems: thrCount != null ? Number(thrCount) : (isFacet && fallbackCount != null) ? Number(fallbackCount) : undefined,
+            numberOfItems: thrCount != null ? Number(thrCount) : (!isStream && fallbackCount != null) ? Number(fallbackCount) : undefined,
             'pse:count': isStream && (pseCount ?? fallbackCount) != null ? Number(pseCount ?? fallbackCount) : undefined,
             'pse:lastRead': isStream && pseLastRead != null ? Number(pseLastRead) : undefined,
             'pse:lastReadDate': isStream ? pseLastReadDate ?? undefined : undefined,


### PR DESCRIPTION
This PR aims to refine the parser so that OPDS 1.x attributes perfectly align with the target [**OPDS 2.0 (Readium WebPub Manifest)**](https://drafts.opds.io/opds-2.0) layout without bleeding deprecated metadata onto the root object, while fixing deep DOM evaluation bugs and bringing support for [OPDS-PSE (Page Streaming)](https://github.com/anansi-project/opds-pse/blob/master/v1.2.md) and [Paging extensions](https://tools.ietf.org/html/rfc5005).

### Improvements & Bug Fixes
* **Aligning OPDS 1.x mapping exclusively with OPDS 2.0 `properties`**:
  * Prevents OPDS 1.2 and OPDS 2.0 hybrid property bleeding onto the root object.
  * Correctly maps [`thr:count`](https://specs.opds.io/opds-1.2.html#the-thrcount-attribute) exclusively to OPDS 2.0's [`properties.numberOfItems`](https://drafts.opds.io/opds-2.0#24-facets).
  * [OpenSearch attributes](https://specs.opds.io/opds-1.2.html#3-search) (`totalResults`, `itemsPerPage`, `startIndex`) are now natively mapped directly into OPDS 2.0 `metadata` [pagination elements](https://drafts.opds.io/opds-2.0#4-pagination) (`numberOfItems`, `itemsPerPage`, `currentPage`).
  * Facet activation ([`opds:activeFacet="true"`](https://specs.opds.io/opds-1.2.html#the-opdsactivefacet-attribute)) is mapped seamlessly by appending the OPDS 2.0 [native `"self"`](https://drafts.opds.io/opds-2.0#24-facets) to the `rel` array instead of preserving the legacy XML attribute.

* **Prices & Indirect Acquisitions Hierarchy Bug Fix**:
  * Previously, `getElementsByTagNameNS(...)[0]` was used. This caused two major issues: it ignored [multiple prices/currencies](https://specs.opds.io/opds-1.2.html#the-opdsprice-element) (e.g., both USD and GBP for the same link) and it broke hierarchy for sibling [nested `indirectAcquisition` branches](https://specs.opds.io/opds-1.2.html#the-opdsindirectacquisition-element) (only capturing the first deep node instead of treating them as trees like an archive bundle with EPUB, MOBI, and PDF inside).
  * Replaced with `getDirectChildren()` to correctly map them strictly inside OPDS 2.0 [`properties.price` and `properties.indirectAcquisition`](https://drafts.opds.io/opds-2.0#53-acquisition-links) maintaining full recursive JSON schema compatibility.

* **OPDS Page Streaming Extension (OPDS-PSE) Support**: 
  * Added [`REL.STREAM`](https://github.com/anansi-project/opds-pse/blob/master/v1.2.md#opds-pse-acquisition-link)  (`http://vaemendis.net/opds-pse/stream`) to properly recognize stream endpoints as OPDS publications rather than navigational entries.
  * Safe-maps [namespaced extensions](https://github.com/anansi-project/opds-pse/blob/master/v1.2.md#specifications)  (`pse:count`, `pse:lastRead`, and `pse:lastReadDate`) into the `properties` object to match the WebPub Manifest specification for custom properties.

* **RFC 5005 (Paging and Archiving)**:
  * Adds evaluation for the [`fh:complete`](https://specs.opds.io/opds-1.2.html#25-complete-acquisition-feeds) and `fh:archive` elements using the `http://purl.org/syndication/history/1.0` namespace exposing them transparently at the root level of the returned feed wrapper.