### PR TITLE
fix(opds): support x-stanza relations and clarify legacy mappings

### DIFF
--- a/opds.js
+++ b/opds.js
@@ -17,11 +17,13 @@ export const REL = {
     GROUP: 'http://opds-spec.org/group',
     COVER: [
         'http://opds-spec.org/image',
-        'http://opds-spec.org/cover',
+        'http://opds-spec.org/cover', // ManyBooks legacy, not in spec
+        'x-stanza-cover-image', // Lexcycle Stanza legacy
     ],
     THUMBNAIL: [
         'http://opds-spec.org/image/thumbnail',
-        'http://opds-spec.org/thumbnail',
+        'http://opds-spec.org/thumbnail', // ManyBooks legacy, not in spec
+        'x-stanza-cover-image-thumbnail', // Lexcycle Stanza legacy
     ],
 }
 


### PR DESCRIPTION
This PR adds support for legacy relations used by Lexcycle Stanza (`x-stanza-cover-image` and `x-stanza-cover-image-thumbnail`).

I also added comments to the existing legacy mappings (used by ManyBooks.net) to explicitly clarify that they are not part of the standard OPDS 1.2 specification, but are kept for compatibility. 

This follows the compatibility criteria used in other projects like KOReader ([#13520](https://github.com/koreader/koreader/issues/13520)) to ensure covers and thumbnails are correctly detected across a wider range of legacy sources.