### PR TITLE
Fix PDF text-to-speech crashes

### DIFF
--- a/tts.js
+++ b/tts.js
@@ -22,7 +22,12 @@ const getAlphabet = el => {
 }
 
 const getSegmenter = (lang = 'en', granularity = 'word') => {
-    const segmenter = new Intl.Segmenter(lang, { granularity })
+    // `lang` may be explicitly null when getLang() walks to the document
+    // root without finding a language attribute — common for PDFs, which
+    // almost never declare a language. The default parameter above only
+    // applies when the argument is `undefined`, not `null`, so we need a
+    // separate fallback here to avoid `Intl.Segmenter(null, ...)` throwing.
+    const segmenter = new Intl.Segmenter(lang || 'en', { granularity })
     const granularityIsWord = granularity === 'word'
     return function* (strs, makeRange) {
         const str = strs.join('')

--- a/view.js
+++ b/view.js
@@ -585,8 +585,14 @@ export class View extends HTMLElement {
         const doc = this.renderer.getContents()[0].doc
         if (this.tts && this.tts.doc === doc) return
         const { TTS } = await import('./tts.js')
-        this.tts = new TTS(doc, textWalker, highlight || (range =>
-            this.renderer.scrollToAnchor(range, true)), granularity)
+        this.tts = new TTS(doc, textWalker, highlight || (range => {
+            // Not every renderer implements scrollToAnchor — in particular,
+            // the PDF renderer is fixed-layout and has no notion of an
+            // anchor to scroll to. Guard the call so that TTS still works
+            // on PDFs, just without sentence-highlight sync.
+            if (typeof this.renderer.scrollToAnchor === 'function')
+                this.renderer.scrollToAnchor(range, true)
+        }), granularity)
     }
     startMediaOverlay() {
         const { index } = this.renderer.getContents()[0]


### PR DESCRIPTION
## Summary

Two small, independent fixes that together restore TTS on PDFs. Both bugs currently make PDF narration unusable:

1. **`tts: fix Intl.Segmenter crash on documents without lang metadata`** — `getLang()` returns `null` when no language attribute is present (the normal case for PDFs). `getSegmenter()`'s default parameter (`lang = 'en'`) only triggers for `undefined`, not `null`, so `new Intl.Segmenter(null, ...)` throws and TTS silently dies before producing a single word. Fix: `lang || 'en'` inside the constructor call.

2. **`view: guard TTS scrollToAnchor for renderers that do not implement it`** — the default TTS highlight callback calls `this.renderer.scrollToAnchor(range, true)`, but the PDF renderer doesn't implement that method (it's fixed-layout, no anchor concept). Every spoken word throws a `CRITICAL` log — non-fatal (audio still plays after the first fix above), but hundreds per page. Fix: wrap the default callback in a `typeof` guard.

Both fixes are scoped to the default PDF path and don't change behavior for reflowable formats or callers that pass their own `highlight` callback.

## Reproduction

Before these fixes, opening any PDF (from arxiv, Google Scholar, anything) and clicking the Narration (headphones) button produces the following console output and no audio:

```
foliate:///foliate-js/tts.js: Unhandled Promise Rejection:
    TypeError: null is not an object (evaluating 'new Intl.Segmenter(lang, { granularity })')
```

With fix 1 applied, audio plays but the console is spammed:

```
com.github.johnfactotum.Foliate-CRITICAL: this.renderer.scrollToAnchor is not a function.
```

With fix 2 applied as well, PDF TTS is quiet and works end-to-end.

## Test plan

- [x] Verified `Intl.Segmenter` crash reproduces on upstream main with a PDF that has no language metadata
- [x] Verified fix makes TTS start and produce audio
- [x] Verified `scrollToAnchor` CRITICAL spam reproduces on same PDF with fix 1 applied
- [x] Verified typeof guard silences the spam without affecting EPUB narration
- [x] Confirmed both fixes are no-ops for reflowable formats and custom `highlight` callbacks

🤖 Generated with [Claude Code](https://claude.com/claude-code)