### PR TITLE
Use original hrefs for external links and add isExternal in fb2.js

### DIFF
--- a/fb2.js
+++ b/fb2.js
@@ -351,6 +351,7 @@ export const makeFB2 = async blob => {
     }
     book.splitTOCHref = href => href?.split('#')?.map(x => Number(x)) ?? []
     book.getTOCFragment = (doc, id) => doc.querySelector(`[${dataID}="${id}"]`)
+    book.isExternal = uri => /^\w+:/i.test(uri)
 
     book.destroy = () => {
         for (const url of urls) URL.revokeObjectURL(url)

--- a/view.js
+++ b/view.js
@@ -357,8 +357,8 @@ export class View extends HTMLElement {
             const href_ = a.getAttribute('href')
             const href = section?.resolveHref?.(href_) ?? href_
             if (book?.isExternal?.(href))
-                Promise.resolve(this.#emit('external-link', { a, href }, true))
-                    .then(x => x ? globalThis.open(href, '_blank') : null)
+                Promise.resolve(this.#emit('external-link', { a, href_ }, true))
+                    .then(x => x ? globalThis.open(href_, '_blank') : null)
                     .catch(e => console.error(e))
             else Promise.resolve(this.#emit('link', { a, href }, true))
                 .then(x => x ? this.goTo(href) : null)


### PR DESCRIPTION
This PR fixes the issue #110 about the removal of search parameters in epub's external links. It also adds an `isExternal` method to the `book` object in `fb2.js`, which otherwise never handles external links.