### PR TITLE
fix: single column mode not working for pdfs

### DIFF
--- a/fixed-layout.js
+++ b/fixed-layout.js
@@ -30,7 +30,7 @@ const getViewport = (doc, viewport) => {
 }
 
 export class FixedLayout extends HTMLElement {
-    static observedAttributes = ['zoom']
+    static observedAttributes = ['zoom', 'max-column-count']
     #root = this.attachShadow({ mode: 'closed' })
     #observer = new ResizeObserver(() => this.#render())
     #spreads
@@ -64,6 +64,9 @@ export class FixedLayout extends HTMLElement {
             case 'zoom':
                 this.#zoom = value !== 'fit-width' && value !== 'fit-page'
                     ? parseFloat(value) : value
+                this.#render()
+                break
+            case 'max-column-count':
                 this.#render()
                 break
         }
@@ -109,8 +112,9 @@ export class FixedLayout extends HTMLElement {
         const right = this.#center ?? this.#right ?? {}
         const target = side === 'left' ? left : right
         const { width, height } = this.getBoundingClientRect()
-        const portrait = this.spread !== 'both' && this.spread !== 'portrait'
-            && height > width
+        const maxCols = parseInt(this.getAttribute('max-column-count'))
+        const portrait = maxCols === 1
+            || (this.spread !== 'both' && this.spread !== 'portrait' && height > width)
         this.#portrait = portrait
         const blankWidth = left.width ?? right.width ?? 0
         const blankHeight = left.height ?? right.height ?? 0


### PR DESCRIPTION
This addresses the issue discussed [here](https://github.com/johnfactotum/foliate/issues/1665).