### PR TITLE
Fix PDF search and result highlighting

### DIFF
--- a/fixed-layout.js
+++ b/fixed-layout.js
@@ -287,7 +287,6 @@ export class FixedLayout extends HTMLElement {
     }
     async select(target) {
         await this.goTo(target)
-        // TODO
     }
     async goTo(target) {
         const { book } = this
@@ -296,6 +295,20 @@ export class FixedLayout extends HTMLElement {
         if (!section) return
         const { index, side } = this.getSpreadOf(section)
         await this.goToSpread(index, side)
+        if (resolved.select && resolved.anchor) {
+            for (const frame of this.#root.querySelectorAll('iframe')) {
+                const doc = frame.contentDocument
+                if (!doc) continue
+                try {
+                    const range = typeof resolved.anchor === 'function' ? resolved.anchor(doc) : resolved.anchor
+                    if (range) {
+                        const sel = doc.defaultView.getSelection()
+                        sel.removeAllRanges()
+                        sel.addRange(range)
+                    }
+                } catch (e) {}
+            }
+        }
     }
     async next() {
         const s = this.rtl ? this.#goLeft() : this.#goRight()

--- a/pdf.js
+++ b/pdf.js
@@ -156,6 +156,25 @@ export const makePDF = async file => {
             cache.set(i, url)
             return url
         },
+        createDocument: async () => {
+            const page = await pdf.getPage(i + 1)
+            const doc = document.implementation.createHTMLDocument()
+            // mirror the rendered iframe structure so search CFIs resolve
+            const canvasDiv = doc.createElement('div')
+            canvasDiv.id = 'canvas'
+            const textLayer = doc.createElement('div')
+            textLayer.className = 'textLayer'
+            const annotationLayer = doc.createElement('div')
+            annotationLayer.className = 'annotationLayer'
+            doc.body.append(canvasDiv, textLayer, annotationLayer)
+            const viewport = page.getViewport({ scale: 1 })
+            await new pdfjsLib.TextLayer({
+                textContentSource: await page.streamTextContent(),
+                container: textLayer,
+                viewport,
+            }).render()
+            return doc
+        },
         size: 1000,
     }))
     book.isExternal = uri => /^\w+:/i.test(uri)


### PR DESCRIPTION
Fixes johnfactotum/foliate#1642                                                                                                                                               
   
  ## Description                                                                                                                                                   
  This PR fixes two issues with PDF search:
  1. Searching within PDF files yielded no results.                                                                                                                
  2. Clicking a CFI target in a fixed-layout document navigated to the page but failed to highlight the text.                                                      
                                                                                                                                                                   
  ### Changes                                                                                                                                                      
                                                                                                                                                                   
  **1. `pdf.js` — `createDocument` for PDF sections**                                                                                                              
  Added a `createDocument` method on each PDF section. It builds a synthetic `HTMLDocument` whose `body` mirrors the rendered iframe structure (`#canvas`,
  `.textLayer`, `.annotationLayer`) and uses `pdfjsLib.TextLayer` with `streamTextContent()` to populate the `.textLayer` with the same span layout pdf.js renders 
  into the iframe. Because the synthetic and rendered DOMs match structurally, search-generated CFIs resolve correctly when applied to the live page.
                                                                                                                                                                   
  **2. `fixed-layout.js` — finish the `select`/`goTo` TODO**                                                                                                       
  Replaced the `// TODO` in `select` with selection logic in `goTo`: after navigating to the spread, if `resolved.select && resolved.anchor`, evaluate the anchor
  against each iframe's `contentDocument` and apply the resulting `Range` via the native `Selection` API.                                                          
                  
  ### Testing                                                                                                                                                      
  - Search inside a PDF returns results across pages.
  - Clicking a search result navigates to the correct page and visibly highlights the matched text.
<img width="1920" height="1060" alt="Screenshot_20260425_203931" src="https://github.com/user-attachments/assets/6dfa336d-813d-4402-8979-05ddc00a0658" />
