### PR TITLE
Fixed layout: unscaled size and safe center

### DIFF
--- a/fixed-layout.js
+++ b/fixed-layout.js
@@ -52,7 +52,7 @@ export class FixedLayout extends HTMLElement {
             width: 100%;
             height: 100%;
             display: flex;
-            justify-content: center;
+            justify-content: safe center;
             align-items: center;
             overflow: auto;
         }`)

--- a/fixed-layout.js
+++ b/fixed-layout.js
@@ -55,6 +55,7 @@ export class FixedLayout extends HTMLElement {
             justify-content: safe center;
             align-items: center;
             overflow: auto;
+            scrollbar-gutter: stable both-edges;
         }`)
 
         this.#observer.observe(this)
@@ -108,7 +109,8 @@ export class FixedLayout extends HTMLElement {
         const left = this.#left ?? {}
         const right = this.#center ?? this.#right ?? {}
         const target = side === 'left' ? left : right
-        const { width, height } = this.getBoundingClientRect()
+        const width = this.clientWidth
+        const height = this.clientHeight
         const portrait = this.spread !== 'both' && this.spread !== 'portrait'
             && height > width
         this.#portrait = portrait


### PR DESCRIPTION
This PR makes two small fixes to the fixed-layout renderer:
* `justify-content: safe center` instead of just `center` to fix issue #67
* `clientWidth` and `clientHeight` instead of `getBoundingClientRect` to get the internal size of the renderer in the `#render` method: if the ebook viewer has been scaled for any reason, `getBoundingClientRect` returns the scaled size, causing the scaling to be applied twice to the pages. Additionally, `getBoundingClientRect` includes the space taken up by the scrollbars (which is 0 in Gecko and Webkit browsers, but not in Chromium): as a result, when the zoom is set to `fit-width` and the page height is greater than the renderer's, the page width doesn't fit completely and a horizontal scrollbar always appears as well. `clientWidth` and `clientHeight`, instead, return only the internal size without the scrollbars, which is more precise. The downside is that the appearance or disappearance of the scrollbar triggers a rerender of the page, so the css rule `scrollbar-gutter: stable both-edges;` is used to stabilize the layout.