### PR TITLE
Add respread method to Fixed Layout renderer

### DIFF
--- a/fixed-layout.js
+++ b/fixed-layout.js
@@ -243,6 +243,17 @@ export class FixedLayout extends HTMLElement {
             return arr
         }, [{}])
     }
+    async respread() {
+        if (!this.book) return
+        const section = this.#index !== -1 ? this.book.sections[this.index] : null
+        this.open(this.book)
+        if (section) {
+            const target = this.getSpreadOf(section)
+            if (!target) return
+            this.#index = -1
+            return this.goToSpread(target.index, target.side, 'page')
+        }
+    }
     get index() {
         const spread = this.#spreads[this.#index]
         const section = spread?.center ?? (this.#side === 'left'


### PR DESCRIPTION
This PR adds to the Fixed Layout renderer the `respread` method, which enables users to recompute the spreads of an ebook and to update the current view accordingly, without losing synch with the View instance.

This allows, for example, to update dynamically the odd pages's side of a comic book or a pdf, something like:
```javascript
const oddPagesTo = side => {
  const { book, renderer } = reader.view
  const toSide = (i % 2 === 0) !== (side === 'left') ? 'right' : 'left'
  book.sections.forEach((section, i) => {
    section.pageSpread = toSide(i)
  })
  renderer.respread().catch(e => console.error(e))
}
```

It uses for the proposed method the same name used in #69, which has been idle for almost a year. If it's a problem I can change it. With respect to #69, this is a much more modest and minimalist proposal: it leaves to the consumer of the library the responsibility of updating the book object as they please.