### PR TITLE
fix: prevent page swipe when selecting text on mobile (#86)

### DIFF
--- a/paginator.js
+++ b/paginator.js
@@ -833,6 +833,11 @@ export class Paginator extends HTMLElement {
         if (state.pinched) return
         state.pinched = globalThis.visualViewport.scale > 1
         if (this.scrolled || state.pinched) return
+
+        const doc = e.target.ownerDocument || document
+        const sel = doc.getSelection()
+        if (sel && sel.type === 'Range' && !sel.isCollapsed) return
+
         if (e.touches.length > 1) {
             if (this.#touchScrolled) e.preventDefault()
             return
@@ -850,9 +855,13 @@ export class Paginator extends HTMLElement {
         this.#touchScrolled = true
         this.scrollBy(dx, dy)
     }
-    #onTouchEnd() {
+    #onTouchEnd(e) {
         this.#touchScrolled = false
         if (this.scrolled) return
+
+        const doc = e?.target?.ownerDocument || document
+        const sel = doc.getSelection()
+        if (sel && sel.type === 'Range' && !sel.isCollapsed) return
 
         // XXX: Firefox seems to report scale as 1... sometimes...?
         // at this point I'm basically throwing `requestAnimationFrame` at


### PR DESCRIPTION
Fixes #86.

This was a recurring issue reported by users in my app (Paperback, built on `foliate-js`). On mobile devices, selecting text triggered page swipes because `paginator.js` called `e.preventDefault()` on touch moves.

This PR checks if text is currently selected (`doc.getSelection()`). If text is being selected, page swiping is bypassed so users can select text freely. Based on our testing, this successfully resolves the issue.