### PR TITLE
Check that page index is valid in #turnPage

### DIFF
--- a/paginator.js
+++ b/paginator.js
@@ -1062,8 +1062,9 @@ export class Paginator extends HTMLElement {
         this.#locked = true
         const prev = dir === -1
         const shouldGo = await (prev ? this.#scrollPrev(distance) : this.#scrollNext(distance))
-        if (shouldGo) await this.#goTo({
-            index: this.#adjacentIndex(dir),
+        const index = this.#adjacentIndex(dir)
+        if (shouldGo && index >= 0) await this.#goTo({
+            index: index,
             anchor: prev ? () => 1 : () => 0,
         })
         if (shouldGo || !this.hasAttribute('animated')) await wait(100)


### PR DESCRIPTION
#adjacentIndex can return undefined when going "back" from the beginning of the book, or "forward" from the end, since the for loop body never executes.

This causes an uncaught error when trying to access the array of sections at an undefined index.

This causes foliate to get "stuck" when trying to go "back" on the first page of a book, or "forward" on the last when using scrolled mode.