### PR TITLE
Fix search dropping excerpt text and throwing on some matches

### DIFF
--- a/search.js
+++ b/search.js
@@ -37,7 +37,10 @@ const simpleSearch = function* (strs, query, options = {}) {
             const startIndex = strIndex
             const startOffset = index - (sum - strs[strIndex].length)
             const end = index + needleLength
-            while (sum <= end) sum += strs[++strIndex].length
+            // stop at the last run; `end` is exclusive, so it can sit exactly
+            // at the end of the text, which no run extends past
+            while (sum <= end && strIndex < strs.length - 1)
+                sum += strs[++strIndex].length
             const endIndex = strIndex
             const endOffset = end - (sum - strs[strIndex].length)
             const range = { startIndex, startOffset, endIndex, endOffset }

--- a/search.js
+++ b/search.js
@@ -6,10 +6,10 @@ const normalizeWhitespace = str => str.replace(/\s+/g, ' ')
 const makeExcerpt = (strs, { startIndex, startOffset, endIndex, endOffset }) => {
     const start = strs[startIndex]
     const end = strs[endIndex]
-    const match = start === end
+    const match = startIndex === endIndex
         ? start.slice(startOffset, endOffset)
         : start.slice(startOffset)
-            + strs.slice(start + 1, end).join('')
+            + strs.slice(startIndex + 1, endIndex).join('')
             + end.slice(0, endOffset)
     const trimmedStart = normalizeWhitespace(start.slice(0, startOffset)).trimStart()
     const trimmedEnd = normalizeWhitespace(end.slice(endOffset)).trimEnd()

--- a/search.js
+++ b/search.js
@@ -37,12 +37,14 @@ const simpleSearch = function* (strs, query, options = {}) {
             const startIndex = strIndex
             const startOffset = index - (sum - strs[strIndex].length)
             const end = index + needleLength
-            // stop at the last run; `end` is exclusive, so it can sit exactly
-            // at the end of the text, which no run extends past
-            while (sum <= end && strIndex < strs.length - 1)
-                sum += strs[++strIndex].length
-            const endIndex = strIndex
-            const endOffset = end - (sum - strs[strIndex].length)
+            // walk to the end on a copy of the cursor, as the next match can
+            // start before this one ends, and stop at the last run, as `end`
+            // is exclusive and can sit right at the end of the text
+            let endIndex = startIndex
+            let endSum = sum
+            while (endSum <= end && endIndex < strs.length - 1)
+                endSum += strs[++endIndex].length
+            const endOffset = end - (endSum - strs[endIndex].length)
             const range = { startIndex, startOffset, endIndex, endOffset }
             yield { range, excerpt: makeExcerpt(strs, range) }
         }

--- a/tests/search-tests.js
+++ b/tests/search-tests.js
@@ -1,0 +1,38 @@
+import { search } from '../search.js'
+
+// `search()` yields `{ range, excerpt }`; the range is turned into a DOM range
+// by the caller, so these tests only cover the excerpts
+const matches = (strs, query, options) =>
+    Array.from(search(strs, query, options), ({ excerpt }) => excerpt)
+
+// what `searchMatcher()` passes for a plain, case-insensitive search
+const GRAPHEME = { granularity: 'grapheme', sensitivity: 'base' }
+
+{
+    // a match spanning more than two text runs must keep the runs in between;
+    // `makeExcerpt()` used to index `strs` with the run contents rather than
+    // the run indices, which silently dropped everything in the middle
+    const [excerpt] = matches(
+        ['Hello ', 'beautiful ', 'world'], 'lo beautiful wo', GRAPHEME)
+    const a = excerpt?.match
+    const b = 'lo beautiful wo'
+    console.assert(a === b, `expected ${b}, got ${a}`)
+}
+
+{
+    // two runs can hold identical text; the excerpt must be built from the run
+    // positions, not by comparing the runs themselves
+    const [excerpt] = matches(['abc', 'abc'], 'ca', GRAPHEME)
+    const a = excerpt?.match
+    const b = 'ca'
+    console.assert(a === b, `expected ${b}, got ${a}`)
+}
+
+{
+    // matches within a single run, and the surrounding context, are unaffected
+    const [excerpt] = matches(['one two three'], 'two', GRAPHEME)
+    for (const [key, b] of [['pre', 'one '], ['match', 'two'], ['post', ' three']]) {
+        const a = excerpt?.[key]
+        console.assert(a === b, `expected ${key} ${b}, got ${a}`)
+    }
+}

--- a/tests/search-tests.js
+++ b/tests/search-tests.js
@@ -63,3 +63,17 @@ const SIMPLE = { granularity: 'grapheme', sensitivity: 'variant' }
         console.assert(a === b, `expected ${key} ${b}, got ${a}`)
     }
 }
+
+{
+    // overlapping matches: walking to the end of one match must not move the
+    // cursor used to find the start of the next, which begins before it ends
+    const results = Array.from(search(['a', 'a', 'a'], 'aa', SIMPLE))
+    console.assert(results.length === 2, `expected 2 matches, got ${results.length}`)
+    for (const [i, b] of [[0, [0, 0, 2, 0]], [1, [1, 0, 2, 1]]]) {
+        const { range, excerpt } = results[i] ?? {}
+        const a = range && [
+            range.startIndex, range.startOffset, range.endIndex, range.endOffset]
+        console.assert(a?.join() === b.join(), `expected range ${b}, got ${a}`)
+        console.assert(excerpt?.match === 'aa', `expected aa, got ${excerpt?.match}`)
+    }
+}

--- a/tests/search-tests.js
+++ b/tests/search-tests.js
@@ -1,7 +1,9 @@
-import { search } from '../search.js'
+import { search, searchMatcher } from '../search.js'
+import { textWalker } from '../text-walker.js'
 
-// `search()` yields `{ range, excerpt }`; the range is turned into a DOM range
-// by the caller, so these tests only cover the excerpts
+// `search()` yields `{ range, excerpt }`, where the range is a set of indices
+// into `strs`; the tests below it cover those, the ones at the end cover the
+// DOM ranges `searchMatcher()` builds from them
 const matches = (strs, query, options) =>
     Array.from(search(strs, query, options), ({ excerpt }) => excerpt)
 
@@ -76,4 +78,51 @@ const SIMPLE = { granularity: 'grapheme', sensitivity: 'variant' }
         console.assert(a?.join() === b.join(), `expected range ${b}, got ${a}`)
         console.assert(excerpt?.match === 'aa', `expected aa, got ${excerpt?.match}`)
     }
+}
+
+// the real path: `searchMatcher()` walks the document, so a single match can
+// span several text nodes, and the offsets it yields are passed straight to
+// `Range.setStart()` / `.setEnd()`, which reject invalid ones outright
+const parser = new DOMParser()
+const doc = body => parser.parseFromString('<html xmlns='
+    + '"http://www.w3.org/1999/xhtml"><head><title>…</title></head><body>'
+    + `${body}</body></html>`, 'application/xhtml+xml')
+
+// case and diacritics without whole words is the `simpleSearch()` route
+const EXACT = { matchCase: true, matchDiacritics: true }
+
+{
+    // inline markup splits a paragraph into separate text nodes, so an
+    // ordinary match already spans several of them
+    const matcher = searchMatcher(textWalker, {})
+    const [result] = Array.from(matcher(
+        doc('<p>Hello <em>beautiful</em> world</p>'), 'lo beautiful wo'))
+    const a = result?.range.toString()
+    const b = 'lo beautiful wo'
+    console.assert(a === b, `expected ${b}, got ${a}`)
+}
+
+{
+    // a match ending at the end of the last text node must not overrun it
+    const matcher = searchMatcher(textWalker, EXACT)
+    const [result] = Array.from(matcher(
+        doc('<p>Hello <em>beautiful</em> world</p>'), 'world'))
+    const a = result?.range.toString()
+    console.assert(a === 'world', `expected world, got ${a}`)
+}
+
+{
+    // overlapping matches across text nodes: sharing the cursor between the
+    // start and the end of a match left a negative offset, which is not a
+    // wrong range but no range at all, as `setStart()` throws on it
+    const matcher = searchMatcher(textWalker, EXACT)
+    let results
+    try {
+        results = Array.from(matcher(doc('<p>a<em>a</em>a</p>'), 'aa'))
+    } catch (e) {
+        console.assert(false, `matching threw: ${e}`)
+    }
+    console.assert(results?.length === 2, `expected 2 matches, got ${results?.length}`)
+    for (const { range } of results ?? [])
+        console.assert(range.toString() === 'aa', `expected aa, got ${range}`)
 }

--- a/tests/search-tests.js
+++ b/tests/search-tests.js
@@ -36,3 +36,30 @@ const GRAPHEME = { granularity: 'grapheme', sensitivity: 'base' }
         console.assert(a === b, `expected ${key} ${b}, got ${a}`)
     }
 }
+
+// matching case or diacritics without whole words goes through `simpleSearch()`
+const SIMPLE = { granularity: 'grapheme', sensitivity: 'variant' }
+
+{
+    // a match reaching the very end of the text must not walk past the last
+    // run while looking for the one holding the (exclusive) end offset
+    for (const strs of [['abc'], ['ab', 'c'], ['a', 'b', 'c']]) {
+        let excerpt
+        try {
+            [excerpt] = matches(strs, 'abc', SIMPLE)
+        } catch (e) {
+            console.assert(false, `threw for ${JSON.stringify(strs)}: ${e}`)
+        }
+        const a = excerpt?.match
+        console.assert(a === 'abc', `expected abc for ${JSON.stringify(strs)}, got ${a}`)
+    }
+}
+
+{
+    // a match ending on a run boundary still keeps the following run as context
+    const [excerpt] = matches(['ab', 'cd'], 'ab', SIMPLE)
+    for (const [key, b] of [['match', 'ab'], ['post', 'cd']]) {
+        const a = excerpt?.[key]
+        console.assert(a === b, `expected ${key} ${b}, got ${a}`)
+    }
+}

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -1,1 +1,2 @@
 import './epubcfi-tests.js'
+import './search-tests.js'


### PR DESCRIPTION
Three bugs in `search.js`, each with tests. All are reachable through `searchMatcher()` on an ordinary document.

## 1. Excerpts drop the text between the first and last run

`makeExcerpt()` indexed `strs` with the run *contents* rather than the run indices:

```js
const start = strs[startIndex]   // a string
const end = strs[endIndex]       // a string
…
    + strs.slice(start + 1, end).join('')
```

`"Hello " + 1` is `"Hello 1"`, which `Array.prototype.slice` coerces to `NaN`, so the slice is empty and every run in between is dropped. For the same reason `start === end` compares runs by content, so two distinct text nodes holding identical text take the single-run branch.

`text-walker.js` produces one run per text node, so any inline markup splits a paragraph and this fires on ordinary searches:

| runs / query | before | after |
|---|---|---|
| `['Hello ','beautiful ','world']` / `lo beautiful wo` | `lo wo` | `lo beautiful wo` |
| `['abc','abc']` / `ca` | *(empty)* | `ca` |

## 2. Out-of-bounds read when a match ends at the end of the text

`simpleSearch()` walks runs until the cumulative length passes the match's end offset, which is exclusive. When a match ends at the very end of the text no run extends past it, so the loop runs off the end of `strs` and throws a `TypeError`.

Reachable by searching for the last word of a section with match-case on. Through `searchMatcher()` the exception escapes the generator, so it takes out the whole search rather than one result.

## 3. The end walk moved the cursor used to find the next match

`sum` and `strIndex` are shared between locating a match's start and locating its end, and persist across iterations of the loop. Matches can overlap, so the next match can begin before the current one ends — which left the cursor past that start and produced a negative `startOffset`.

`makeRange()` passes that straight to `Range.setStart()`, which rejects it, so the symptom is a thrown `IndexSizeError` rather than a merely wrong highlight. Previously this input hit the out-of-bounds read above and threw first; fixing that alone would have turned it into a silently wrong result, so the two go together.

Fixed by walking to the end on local copies of the cursor.

## Tests

`tests/search-tests.js` covers the offsets `search()` yields, and then the DOM ranges `searchMatcher()` builds from them via `text-walker.js`. Every assertion was confirmed failing against `main` and passing after the fix, in both Chromium and WebKit.

The file needs a DOM, so it runs from `tests/tests.html` rather than bare Node — same as `epubcfi-tests.js`.

## Not included

While in here I noticed that `search()` resolves defaults for `granularity` and `sensitivity` but forwards the original `options` object, while `segmenterSearch()` defaults `granularity` to `'word'`. So `search(strs, query, {})` matches whole words rather than the `'grapheme'` that `search()`'s own default implies. `searchMatcher()` always passes `granularity` explicitly, so nothing in the library is affected.

That reads more like an API decision than a bug, so I have left it out of this PR. Happy to open it separately if you would like the two defaults reconciled.
