### PR TITLE
Fix quote images never rendering

### DIFF
--- a/quote-image.js
+++ b/quote-image.js
@@ -63,7 +63,7 @@ customElements.define('foliate-quoteimage', class extends HTMLElement {
         fit(this.#root.querySelector('main'))
 
         const img = document.createElement('img')
-        return new Promise(resolve => {
+        return new Promise((resolve, reject) => {
             img.onload = () => {
                 const canvas = document.createElement('canvas')
                 canvas.width = pixelRatio * width
@@ -72,6 +72,7 @@ customElements.define('foliate-quoteimage', class extends HTMLElement {
                 ctx.drawImage(img, 0, 0, canvas.width, canvas.height)
                 canvas.toBlob(resolve)
             }
+            img.onerror = () => reject(new Error('Failed to render quote image'))
             const doc = document.implementation.createDocument(SVG_NS, 'svg')
             doc.documentElement.setAttribute('viewBox', `0 0 ${width} ${height}`)
             const obj = doc.createElementNS(SVG_NS, 'foreignObject')
@@ -79,8 +80,12 @@ customElements.define('foliate-quoteimage', class extends HTMLElement {
             obj.setAttribute('height', height)
             obj.append(doc.importNode(this.#root.querySelector('main'), true))
             doc.documentElement.append(obj)
-            img.src = 'data:image/svg+xml;charset=utf-8,'
-                + new XMLSerializer().serializeToString(doc)
+            // percent-encode the document: an unescaped `#` starts the URL
+            // fragment and `%` an escape sequence, and both occur here, as the
+            // styles above use hex colours and the text can contain anything;
+            // a selection can also split a surrogate pair, which will not encode
+            img.src = 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent(
+                new XMLSerializer().serializeToString(doc).toWellFormed())
         })
     }
 })

--- a/tests/quote-image-tests.js
+++ b/tests/quote-image-tests.js
@@ -1,0 +1,29 @@
+import '../quote-image.js'
+
+const timeout = (promise, ms) => Promise.race([promise,
+    new Promise((resolve, reject) =>
+        setTimeout(() => reject(new Error(`timed out after ${ms}ms`)), ms))])
+
+{
+    // the SVG is serialized into a data URL, and `#` starts the URL fragment,
+    // so anything after the first one used to be dropped, leaving an image
+    // that could never load and a promise that never settled; note the
+    // template's own colours contain `#`, so this held for any input at all
+    const el = document.createElement('foliate-quoteimage')
+    document.body.append(el)
+    let blob
+    try {
+        blob = await timeout(el.getBlob({
+            title: 'The #1 Book',
+            author: '100% Author',
+            // `%20` would be decoded were only `#` escaped, and the lone
+            // surrogate is what a selection split through a pair produces
+            text: 'Chapter #3, 50%20 done, 中文, 😀, \uD800',
+        }), 10000)
+    } catch (e) {
+        console.assert(false, `getBlob() rejected: ${e.message}`)
+    }
+    console.assert(blob instanceof Blob, `expected a Blob, got ${blob}`)
+    console.assert(blob?.size > 0, `expected a non-empty blob, got ${blob?.size}`)
+    el.remove()
+}

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -1,1 +1,2 @@
 import './epubcfi-tests.js'
+import './quote-image-tests.js'


### PR DESCRIPTION
`getBlob()` in `quote-image.js` never resolves, for any input.

The SVG is serialized straight into a `data:` URL. An unescaped `#` starts the URL fragment and truncates the payload — and the template's own styles set `background: #fff`, so the truncation happens on every call regardless of what the quote contains:

```
data:image/svg+xml;charset=utf-8,<svg …><main style="…; background:
                                                                   ↑ dropped from here
```

The image can then never load, and as only `onload` was wired up, the returned promise never settles. A `%` in the title, author or text was a second way in.

Confirmed against `main` in both Chromium and WebKit: the promise stays pending until the test's timeout fires.

## The fix

- Percent-encode the serialized document.
- A selection can be split through a surrogate pair, and `encodeURIComponent()` throws `URIError` on a lone surrogate, so the string is made well-formed first.
- Reject on `error`, so a failure to render surfaces instead of hanging. This is a contract change for consumers, though the contract it replaces was a promise that never settled.

## Tests

`tests/quote-image-tests.js` renders a quote containing `#`, `%20`, CJK, an emoji and a lone surrogate, then asserts a non-empty `Blob` comes back. It fails against `main` on 3 assertions and passes with the fix, in both Chromium and WebKit.

This is the first test in the suite that needs canvas rendering, so it costs roughly a second where the existing tests are instant. Say the word if you would rather it lived somewhere separate from `tests/tests.html`.

## One thing you may want done differently

A `blob:` URL would sidestep the escaping and the URL-length ceiling entirely. I did not do that, because `data:` looks like a deliberate choice here given that `blob:` is used throughout the rest of the library, and switching adds object-URL lifetime management for what is not a practical limit — the encoded data URL's ceiling is on the order of a hundred million characters. Happy to switch it if you prefer.
